### PR TITLE
Issue #5: Ctrl + Keybinding for Zoom In does not work

### DIFF
--- a/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/ui/scaling/ScalingUiBindingConfiguration.java
+++ b/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/ui/scaling/ScalingUiBindingConfiguration.java
@@ -78,6 +78,10 @@ public class ScalingUiBindingConfiguration extends AbstractUiBindingConfiguratio
                 new ZoomInScalingAction(this.updater));
 
         uiBindingRegistry.registerKeyBinding(
+                new KeyEventMatcher(SWT.MOD1, '='),
+                new ZoomInScalingAction(this.updater));
+
+        uiBindingRegistry.registerKeyBinding(
                 new KeyEventMatcher(SWT.MOD1, '-'),
                 new ZoomOutScalingAction(this.updater));
 


### PR DESCRIPTION
Adds another ZoomInScalingAction keybinding in
ScalingUiBindingConfiguration, bound to ctrl =. This enables the ZoomInScalingAction keybinding for keyboards for which +/= are the same key and + is actually shift =.