### PR TITLE
Fixes #7 - [Filter] Rendering issue on filtering when scrolled to right

### DIFF
--- a/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/filterrow/combobox/FilterRowComboBoxCellEditor.java
+++ b/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/filterrow/combobox/FilterRowComboBoxCellEditor.java
@@ -127,7 +127,7 @@ public class FilterRowComboBoxCellEditor extends ComboBoxCellEditor {
                             colPos,
                             getRowPosition());
 
-            if (getColumnPosition() < colPos || !cell.getBounds().equals(bounds)) {
+            if (getColumnPosition() < colPos || (cell != null && !cell.getBounds().equals(bounds))) {
                 close();
                 EditController.editCell(
                         cell,


### PR DESCRIPTION
Fixed possible NPE if the filter dropdown is opened while a scrollbar is not visible, and the scrollbar becomes visible on changing the filter again.