### PR TITLE
Impl #17 - Add config for multi-edit if not all cells are editable

### DIFF
--- a/org.eclipse.nebula.widgets.nattable.core.test/src/org/eclipse/nebula/widgets/nattable/edit/command/EditSelectionCommandHandlerTest.java
+++ b/org.eclipse.nebula.widgets.nattable.core.test/src/org/eclipse/nebula/widgets/nattable/edit/command/EditSelectionCommandHandlerTest.java
@@ -1,0 +1,179 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Dirk Fauth and others.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Dirk Fauth <dirk.fauth@googlemail.com> - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.nebula.widgets.nattable.edit.command;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collection;
+
+import org.eclipse.nebula.widgets.nattable.config.IEditableRule;
+import org.eclipse.nebula.widgets.nattable.edit.EditConfigAttributes;
+import org.eclipse.nebula.widgets.nattable.layer.DataLayer;
+import org.eclipse.nebula.widgets.nattable.layer.cell.ILayerCell;
+import org.eclipse.nebula.widgets.nattable.layer.stack.DummyGridLayerStack;
+import org.eclipse.nebula.widgets.nattable.selection.SelectionLayer;
+import org.eclipse.nebula.widgets.nattable.style.DisplayMode;
+import org.eclipse.nebula.widgets.nattable.test.fixture.NatTableFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class EditSelectionCommandHandlerTest {
+
+    private static final String TEST_LABEL = "testLabel";
+
+    private NatTableFixture natTable;
+    private DummyGridLayerStack gridLayerStack;
+    private SelectionLayer selectionLayer;
+    private EditSelectionCommandHandler handler;
+
+    @BeforeEach
+    public void setup() {
+        this.gridLayerStack = new DummyGridLayerStack(5, 5);
+        this.selectionLayer = this.gridLayerStack.getBodyLayer().getSelectionLayer();
+        this.natTable = new NatTableFixture(this.gridLayerStack);
+
+        this.handler = new EditSelectionCommandHandler(this.selectionLayer);
+
+        // Ensure no active editor (static) is present
+        assertNull(this.natTable.getActiveCellEditor());
+    }
+
+    @Test
+    public void shouldHandleOnlyAllEditable() {
+        // by default editing should only be possible if all cells are editable
+        assertTrue(this.handler.handleOnlyAllSelectedEditable(this.natTable.getConfigRegistry()));
+    }
+
+    @Test
+    public void shouldHandleOnlyAllEditableViaConfiguration() {
+        this.natTable.getConfigRegistry().registerConfigAttribute(
+                EditConfigAttributes.MULTI_EDIT_ALL_SELECTED_EDITABLE,
+                true);
+        assertTrue(this.handler.handleOnlyAllSelectedEditable(this.natTable.getConfigRegistry()));
+    }
+
+    @Test
+    public void shouldHandleAllEditableInSelection() {
+        this.natTable.getConfigRegistry().registerConfigAttribute(
+                EditConfigAttributes.MULTI_EDIT_ALL_SELECTED_EDITABLE,
+                false);
+        assertFalse(this.handler.handleOnlyAllSelectedEditable(this.natTable.getConfigRegistry()));
+    }
+
+    @Test
+    public void testGetSelectedCellsForEditing() {
+        this.selectionLayer.selectCell(1, 1, false, true);
+        this.selectionLayer.selectCell(2, 2, false, true);
+        this.selectionLayer.selectCell(3, 3, false, true);
+
+        Collection<ILayerCell> cellsForEditing = this.handler.getCellsForEditing(this.selectionLayer, null, this.natTable.getConfigRegistry(), false);
+
+        // by default check if all selected cells are editable, as editing is
+        // disabled, no cells are returned
+        assertEquals(0, cellsForEditing.size());
+    }
+
+    @Test
+    public void testGetSelectedCellsForEditingEditingEnabled() {
+        this.natTable.enableEditingOnAllCells();
+
+        this.selectionLayer.selectCell(1, 1, false, true);
+        this.selectionLayer.selectCell(2, 2, false, true);
+        this.selectionLayer.selectCell(3, 3, false, true);
+
+        Collection<ILayerCell> cellsForEditing = this.handler.getCellsForEditing(this.selectionLayer, null, this.natTable.getConfigRegistry(), false);
+
+        assertEquals(3, cellsForEditing.size());
+    }
+
+    @Test
+    public void testGetSelectedCellsForEditingEditingEnabledForSingleCell() {
+        DataLayer bodyDataLayer = (DataLayer) this.gridLayerStack.getBodyDataLayer();
+        this.natTable.registerLabelOnColumn(bodyDataLayer, 2, TEST_LABEL);
+        this.natTable.getConfigRegistry().registerConfigAttribute(
+                EditConfigAttributes.CELL_EDITABLE_RULE,
+                IEditableRule.ALWAYS_EDITABLE,
+                DisplayMode.EDIT,
+                TEST_LABEL);
+
+        this.selectionLayer.selectCell(1, 1, false, true);
+        this.selectionLayer.selectCell(2, 2, false, true);
+        this.selectionLayer.selectCell(3, 3, false, true);
+
+        Collection<ILayerCell> cellsForEditing = this.handler.getCellsForEditing(this.selectionLayer, null, this.natTable.getConfigRegistry(), false);
+
+        // not all selected cells are editable, so no cells
+        assertEquals(0, cellsForEditing.size());
+    }
+
+    @Test
+    public void testGetSelectedCellsForEditingHandleSelectedEditable() {
+        this.natTable.getConfigRegistry().registerConfigAttribute(
+                EditConfigAttributes.MULTI_EDIT_ALL_SELECTED_EDITABLE,
+                false);
+
+        this.selectionLayer.selectCell(1, 1, false, true);
+        this.selectionLayer.selectCell(2, 2, false, true);
+        this.selectionLayer.selectCell(3, 3, false, true);
+
+        Collection<ILayerCell> cellsForEditing = this.handler.getCellsForEditing(this.selectionLayer, null, this.natTable.getConfigRegistry(), false);
+
+        // as editing is disabled, no cells are returned
+        assertEquals(0, cellsForEditing.size());
+    }
+
+    @Test
+    public void testGetSelectedCellsForEditingHandleSelectedEditableEditingEnabled() {
+        this.natTable.getConfigRegistry().registerConfigAttribute(
+                EditConfigAttributes.MULTI_EDIT_ALL_SELECTED_EDITABLE,
+                false);
+
+        this.natTable.enableEditingOnAllCells();
+
+        this.selectionLayer.selectCell(1, 1, false, true);
+        this.selectionLayer.selectCell(2, 2, false, true);
+        this.selectionLayer.selectCell(3, 3, false, true);
+
+        Collection<ILayerCell> cellsForEditing = this.handler.getCellsForEditing(this.selectionLayer, null, this.natTable.getConfigRegistry(), false);
+
+        assertEquals(3, cellsForEditing.size());
+    }
+
+    @Test
+    public void testGetSelectedCellsForEditingHandleSelectedEditableEditingEnabledForSingleCell() {
+        this.natTable.getConfigRegistry().registerConfigAttribute(
+                EditConfigAttributes.MULTI_EDIT_ALL_SELECTED_EDITABLE,
+                false);
+
+        DataLayer bodyDataLayer = (DataLayer) this.gridLayerStack.getBodyDataLayer();
+        this.natTable.registerLabelOnColumn(bodyDataLayer, 2, TEST_LABEL);
+        this.natTable.getConfigRegistry().registerConfigAttribute(
+                EditConfigAttributes.CELL_EDITABLE_RULE,
+                IEditableRule.ALWAYS_EDITABLE,
+                DisplayMode.EDIT,
+                TEST_LABEL);
+
+        this.selectionLayer.selectCell(1, 1, false, true);
+        this.selectionLayer.selectCell(2, 2, false, true);
+        this.selectionLayer.selectCell(3, 3, false, true);
+
+        Collection<ILayerCell> cellsForEditing = this.handler.getCellsForEditing(this.selectionLayer, null, this.natTable.getConfigRegistry(), false);
+
+        // only one of the selected cells is editable, so size is 1
+        assertEquals(1, cellsForEditing.size());
+    }
+
+}

--- a/org.eclipse.nebula.widgets.nattable.core.test/src/org/eclipse/nebula/widgets/nattable/edit/command/EditUtilsTest.java
+++ b/org.eclipse.nebula.widgets.nattable.core.test/src/org/eclipse/nebula/widgets/nattable/edit/command/EditUtilsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2020 Dirk Fauth and others.
+ * Copyright (c) 2013, 2023 Dirk Fauth and others.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -18,7 +18,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Collection;
+
 import org.eclipse.nebula.widgets.nattable.config.CellConfigAttributes;
+import org.eclipse.nebula.widgets.nattable.config.IEditableRule;
 import org.eclipse.nebula.widgets.nattable.coordinate.PositionCoordinate;
 import org.eclipse.nebula.widgets.nattable.data.convert.DefaultBooleanDisplayConverter;
 import org.eclipse.nebula.widgets.nattable.edit.EditConfigAttributes;
@@ -199,7 +202,8 @@ public class EditUtilsTest {
         this.natTable.getConfigRegistry().registerConfigAttribute(
                 EditConfigAttributes.CELL_EDITOR,
                 new CheckBoxCellEditor(),
-                DisplayMode.EDIT, TEST_LABEL);
+                DisplayMode.EDIT,
+                TEST_LABEL);
 
         assertFalse(EditUtils.isEditorSame(this.selectionLayer, this.natTable.getConfigRegistry()));
     }
@@ -272,4 +276,52 @@ public class EditUtilsTest {
         assertTrue(EditUtils.isValueSame(this.selectionLayer));
     }
 
+    @Test
+    public void testGetSelectedCellsForEditing() {
+        this.selectionLayer.selectCell(1, 1, false, true);
+        this.selectionLayer.selectCell(2, 2, false, true);
+        this.selectionLayer.selectCell(3, 3, false, true);
+
+        Collection<ILayerCell> selectedCellsForEditing = EditUtils.getSelectedCellsForEditing(this.selectionLayer);
+        Collection<ILayerCell> editableCellsInSelection = EditUtils.getEditableCellsInSelection(this.selectionLayer, this.natTable.getConfigRegistry());
+
+        assertEquals(3, selectedCellsForEditing.size());
+        assertEquals(0, editableCellsInSelection.size());
+    }
+
+    @Test
+    public void testGetSelectedCellsForEditingEditingEnabled() {
+        this.natTable.enableEditingOnAllCells();
+
+        this.selectionLayer.selectCell(1, 1, false, true);
+        this.selectionLayer.selectCell(2, 2, false, true);
+        this.selectionLayer.selectCell(3, 3, false, true);
+
+        Collection<ILayerCell> selectedCellsForEditing = EditUtils.getSelectedCellsForEditing(this.selectionLayer);
+        Collection<ILayerCell> editableCellsInSelection = EditUtils.getEditableCellsInSelection(this.selectionLayer, this.natTable.getConfigRegistry());
+
+        assertEquals(3, selectedCellsForEditing.size());
+        assertEquals(3, editableCellsInSelection.size());
+    }
+
+    @Test
+    public void testGetSelectedCellsForEditingEditingEnabledForSingleCell() {
+        DataLayer bodyDataLayer = (DataLayer) this.gridLayerStack.getBodyDataLayer();
+        this.natTable.registerLabelOnColumn(bodyDataLayer, 2, TEST_LABEL);
+        this.natTable.getConfigRegistry().registerConfigAttribute(
+                EditConfigAttributes.CELL_EDITABLE_RULE,
+                IEditableRule.ALWAYS_EDITABLE,
+                DisplayMode.EDIT,
+                TEST_LABEL);
+
+        this.selectionLayer.selectCell(1, 1, false, true);
+        this.selectionLayer.selectCell(2, 2, false, true);
+        this.selectionLayer.selectCell(3, 3, false, true);
+
+        Collection<ILayerCell> selectedCellsForEditing = EditUtils.getSelectedCellsForEditing(this.selectionLayer);
+        Collection<ILayerCell> editableCellsInSelection = EditUtils.getEditableCellsInSelection(this.selectionLayer, this.natTable.getConfigRegistry());
+
+        assertEquals(3, selectedCellsForEditing.size());
+        assertEquals(1, editableCellsInSelection.size());
+    }
 }

--- a/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/edit/EditConfigAttributes.java
+++ b/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/edit/EditConfigAttributes.java
@@ -145,4 +145,15 @@ public final class EditConfigAttributes {
      * @see ICellEditDialog#DIALOG_MESSAGE
      */
     public static final ConfigAttribute<Map<String, Object>> EDIT_DIALOG_SETTINGS = new ConfigAttribute<>();
+
+    /**
+     * The configuration attribute to specify if multi-edit should only be
+     * possible if all selected cells are editable (default) or if the not
+     * editable cells should be ignored in the processing. If there is no value
+     * set for this configuration attribute, the default <code>true</code> is
+     * used.
+     *
+     * @since 2.3
+     */
+    public static final ConfigAttribute<Boolean> MULTI_EDIT_ALL_SELECTED_EDITABLE = new ConfigAttribute<>();
 }

--- a/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/edit/command/EditSelectionCommandHandler.java
+++ b/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/edit/command/EditSelectionCommandHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2020 Original authors and others.
+ * Copyright (c) 2012, 2023 Original authors and others.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,15 +13,19 @@
 package org.eclipse.nebula.widgets.nattable.edit.command;
 
 import java.util.Collection;
+import java.util.Collections;
 
 import org.eclipse.nebula.widgets.nattable.command.AbstractLayerCommandHandler;
 import org.eclipse.nebula.widgets.nattable.config.IConfigRegistry;
+import org.eclipse.nebula.widgets.nattable.config.IEditableRule;
 import org.eclipse.nebula.widgets.nattable.coordinate.PositionCoordinate;
+import org.eclipse.nebula.widgets.nattable.edit.EditConfigAttributes;
 import org.eclipse.nebula.widgets.nattable.edit.EditController;
 import org.eclipse.nebula.widgets.nattable.edit.event.InlineCellEditEvent;
 import org.eclipse.nebula.widgets.nattable.layer.IUniqueIndexLayer;
 import org.eclipse.nebula.widgets.nattable.layer.cell.ILayerCell;
 import org.eclipse.nebula.widgets.nattable.selection.SelectionLayer;
+import org.eclipse.nebula.widgets.nattable.style.DisplayMode;
 import org.eclipse.swt.widgets.Composite;
 
 /**
@@ -77,41 +81,40 @@ public class EditSelectionCommandHandler extends AbstractLayerCommandHandler<Edi
         IConfigRegistry configRegistry = command.getConfigRegistry();
         Character initialValue = command.getCharacter();
 
-        if (EditUtils.allCellsEditable(this.selectionLayer, this.upperLayer, configRegistry)
-                && EditUtils.isEditorSame(this.selectionLayer, this.upperLayer, configRegistry)
-                && EditUtils.isConverterSame(this.selectionLayer, this.upperLayer, configRegistry)
-                && EditUtils.activateLastSelectedCellEditor(this.selectionLayer, configRegistry, command.isByTraversal())) {
+        Collection<ILayerCell> selectedCells = getCellsForEditing(
+                this.selectionLayer,
+                this.upperLayer,
+                configRegistry,
+                command.isByTraversal());
 
-            // check how many cells are selected
-            Collection<ILayerCell> selectedCells = EditUtils.getSelectedCellsForEditing(this.selectionLayer, this.upperLayer);
-            if (selectedCells.size() == 1) {
-                // editing is triggered by key for a single cell
-                // we need to fire the InlineCellEditEvent here because we
-                // don't know the correct bounds of the cell to edit inline
-                // corresponding to the NatTable.
-                // On firing the event, a translation process is triggered,
-                // converting the information to the correct values
-                // needed for inline editing
+        // check how many cells are selected
+        if (selectedCells.size() == 1) {
+            // editing is triggered by key for a single cell
+            // we need to fire the InlineCellEditEvent here because we
+            // don't know the correct bounds of the cell to edit inline
+            // corresponding to the NatTable.
+            // On firing the event, a translation process is triggered,
+            // converting the information to the correct values
+            // needed for inline editing
+            ILayerCell cell = selectedCells.iterator().next();
+            this.selectionLayer.fireLayerEvent(
+                    new InlineCellEditEvent(
+                            new PositionCoordinate(this.selectionLayer, cell.getOriginColumnPosition(), cell.getOriginRowPosition()),
+                            parent,
+                            configRegistry,
+                            (initialValue != null ? initialValue : cell.getDataValue())));
+        } else if (selectedCells.size() > 1) {
+            // determine the initial value
+            Object initialEditValue = initialValue;
+            if (initialValue == null
+                    && EditUtils.isValueSame(this.selectionLayer, this.upperLayer)) {
                 ILayerCell cell = selectedCells.iterator().next();
-                this.selectionLayer.fireLayerEvent(
-                        new InlineCellEditEvent(
-                                new PositionCoordinate(this.selectionLayer, cell.getOriginColumnPosition(), cell.getOriginRowPosition()),
-                                parent,
-                                configRegistry,
-                                (initialValue != null ? initialValue : cell.getDataValue())));
-            } else if (selectedCells.size() > 1) {
-                // determine the initial value
-                Object initialEditValue = initialValue;
-                if (initialValue == null
-                        && EditUtils.isValueSame(this.selectionLayer, this.upperLayer)) {
-                    ILayerCell cell = selectedCells.iterator().next();
-                    initialEditValue = this.selectionLayer.getDataValueByPosition(
-                            cell.getColumnPosition(),
-                            cell.getRowPosition());
-                }
-
-                EditController.editCells(selectedCells, parent, initialEditValue, configRegistry);
+                initialEditValue = this.selectionLayer.getDataValueByPosition(
+                        cell.getColumnPosition(),
+                        cell.getRowPosition());
             }
+
+            EditController.editCells(selectedCells, parent, initialEditValue, configRegistry);
         }
 
         // as commands by default are intended to be consumed by the handler,
@@ -120,4 +123,67 @@ public class EditSelectionCommandHandler extends AbstractLayerCommandHandler<Edi
         return true;
     }
 
+    /**
+     * Retrieve the cells that should be edited.
+     *
+     * @param selectionLayer
+     *            The {@link SelectionLayer} to retrieve the current selection.
+     * @param upperLayer
+     *            The layer on top of the given {@link SelectionLayer} to which
+     *            the selection should be converted to. Can be <code>null</code>
+     *            which causes the resulting selected cells to be related to the
+     *            {@link SelectionLayer}.
+     * @param configRegistry
+     *            The {@link IConfigRegistry} needed to access the configured
+     *            {@link IEditableRule}s and the configuration if only editing
+     *            should only be possible if all selected cells are editable, or
+     *            if all editable cells that are selected should be used.
+     * @param byTraversal
+     *            <code>true</code> if the activation is triggered by traversal,
+     *            <code>false</code> if not.
+     * @return The selected {@link ILayerCell}s that should be edited, related
+     *         to the given upperLayer.
+     * @since 2.3
+     */
+    protected Collection<ILayerCell> getCellsForEditing(
+            SelectionLayer selectionLayer,
+            IUniqueIndexLayer upperLayer,
+            IConfigRegistry configRegistry,
+            boolean byTraversal) {
+
+        Collection<ILayerCell> selectedCells = handleOnlyAllSelectedEditable(configRegistry)
+                ? EditUtils.getSelectedCellsForEditing(selectionLayer, upperLayer)
+                : EditUtils.getEditableCellsInSelection(selectionLayer, upperLayer, configRegistry);
+
+        if (EditUtils.allCellsEditable(selectedCells, configRegistry)
+                && EditUtils.isEditorSame(selectedCells, configRegistry)
+                && EditUtils.isConverterSame(selectedCells, configRegistry)
+                && EditUtils.activateLastSelectedCellEditor(selectionLayer, configRegistry, byTraversal)) {
+
+            return selectedCells;
+        }
+        return Collections.emptyList();
+    }
+
+    /**
+     * Return whether a multi-edit should only be allowed if all selected cells
+     * are editable, or if the non-editable cells should be simply ignored.
+     *
+     * @param configRegistry
+     *            The {@link IConfigRegistry} needed to retrieve the config
+     *            attribute.
+     * @return <code>true</code> if multi-edit should only be possible if all
+     *         selected cells are editable, <code>false</code> if the
+     *         non-editable cells should be simply ignored.
+     * @see EditConfigAttributes#MULTI_EDIT_ALL_SELECTED_EDITABLE
+     * @since 2.3
+     */
+    protected boolean handleOnlyAllSelectedEditable(IConfigRegistry configRegistry) {
+        Boolean allEditable = configRegistry.getConfigAttribute(
+                EditConfigAttributes.MULTI_EDIT_ALL_SELECTED_EDITABLE,
+                DisplayMode.EDIT);
+
+        return (allEditable == null) ? true : allEditable.booleanValue();
+
+    }
 }


### PR DESCRIPTION
Added the following API:

- EditUtils#getEditableCellsInSelection()
- EditSelectionCommandHandler#handleOnlyAllSelectedEditable(IConfigRegistry)
- EditSelectionCommandHandler#getEditableCellsInSelection(SelectionLayer, IConfigRegistry)
- EditConfigAttributes#MULTI_EDIT_ALL_SELECTED_EDITABLE

With this modification it is possible to change the behavior whether a multi-edit should be possible only if all selected cells are editable, or if multi-edit should only handle the editable cells in the selection. The change can be done programmatically by overriding methods in EditSelectionCommandHandler, or via the newly introduced EditConfigAttribute.