### PR TITLE
Fixes #21 - [RichText] MarkupDisplayConverter fails special characters

### DIFF
--- a/org.eclipse.nebula.widgets.nattable.extension.nebula.feature/feature.xml
+++ b/org.eclipse.nebula.widgets.nattable.extension.nebula.feature/feature.xml
@@ -46,4 +46,11 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.apache.commons.lang3"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>

--- a/org.eclipse.nebula.widgets.nattable.extension.nebula/META-INF/MANIFEST.MF
+++ b/org.eclipse.nebula.widgets.nattable.extension.nebula/META-INF/MANIFEST.MF
@@ -6,7 +6,8 @@ Bundle-Version: 2.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.nebula.widgets.nattable.extension.nebula.cdatetime;version="1.1.0",
  org.eclipse.nebula.widgets.nattable.extension.nebula.richtext;version="2.3.0"
-Import-Package: org.eclipse.nebula.cwt.base,
+Import-Package: org.apache.commons.lang3;version="[3.1.0,4.0.0)",
+ org.eclipse.nebula.cwt.base,
  org.eclipse.nebula.cwt.v,
  org.eclipse.nebula.widgets.cdatetime,
  org.eclipse.nebula.widgets.nattable.command;version="[2.1.0,3.0.0)",

--- a/org.eclipse.nebula.widgets.nattable.extension.nebula/src/org/eclipse/nebula/widgets/nattable/extension/nebula/richtext/MarkupDisplayConverter.java
+++ b/org.eclipse.nebula.widgets.nattable.extension.nebula/src/org/eclipse/nebula/widgets/nattable/extension/nebula/richtext/MarkupDisplayConverter.java
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2015, 2020 CEA LIST.
+ * Copyright (c) 2015, 2023 CEA LIST.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,6 +19,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.eclipse.nebula.widgets.nattable.config.IConfigRegistry;
 import org.eclipse.nebula.widgets.nattable.data.convert.ContextualDisplayConverter;
 import org.eclipse.nebula.widgets.nattable.data.convert.DefaultDisplayConverter;
@@ -49,6 +50,8 @@ public class MarkupDisplayConverter extends ContextualDisplayConverter {
         String result = null;
         if (wrappedConverterResult != null) {
             result = wrappedConverterResult.toString();
+
+            result = StringEscapeUtils.escapeHtml4(String.valueOf(result));
 
             // add markups
             for (MarkupProcessor markup : this.markups.values()) {

--- a/target-platform/target-platform.target
+++ b/target-platform/target-platform.target
@@ -17,6 +17,7 @@
       <unit id="ca.odell.glazedlists" version="1.11.0.v20190926-1838"/>
       <unit id="org.apache.commons.collections4" version="4.4.0.v20200420-1700"/>
       <unit id="org.apache.commons.codec" version="1.14.0.v20200818-1422"/>
+      <unit id="org.apache.commons.lang3" version="3.1.0.v201403281430"/>
       <unit id="org.apache.commons.math3" version="3.6.1.v20200817-1830"/>
       <unit id="org.apache.poi" version="4.1.1.v20200604-1524"/>
       <unit id="org.slf4j.api" version="1.7.30.v20200204-2150"/>


### PR DESCRIPTION
Added a new dependency to `org.apache.commons.lang3` to be able to use `org.apache.commons.lang3.StringEscapeUtils` to escape the input. The escaping is added in the `MarkupDisplayConverter` and the `RegexMarkupValue`.