### PR TITLE
Impl #35 - [Context Menu] Add support for adding sub menus

### DIFF
--- a/org.eclipse.nebula.widgets.nattable.core/.settings/.api_filters
+++ b/org.eclipse.nebula.widgets.nattable.core/.settings/.api_filters
@@ -8,6 +8,14 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="src/org/eclipse/nebula/widgets/nattable/ui/menu/PopupMenuBuilder.java" type="org.eclipse.nebula.widgets.nattable.ui.menu.PopupMenuBuilder">
+        <filter id="336658481">
+            <message_arguments>
+                <message_argument value="org.eclipse.nebula.widgets.nattable.ui.menu.PopupMenuBuilder"/>
+                <message_argument value="parentBuilder"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="src/org/eclipse/nebula/widgets/nattable/widget/NatCombo.java" type="org.eclipse.nebula.widgets.nattable.widget.NatCombo">
         <filter id="336658481">
             <message_arguments>

--- a/org.eclipse.nebula.widgets.nattable.examples.e4/src/org/eclipse/nebula/widgets/nattable/examples/e4/part/MenuExample.java
+++ b/org.eclipse.nebula.widgets.nattable.examples.e4/src/org/eclipse/nebula/widgets/nattable/examples/e4/part/MenuExample.java
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2019, 2020 Dirk Fauth.
+ * Copyright (c) 2019, 2023 Dirk Fauth.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -27,7 +27,6 @@ import org.eclipse.nebula.widgets.nattable.config.DefaultNatTableStyleConfigurat
 import org.eclipse.nebula.widgets.nattable.data.IDataProvider;
 import org.eclipse.nebula.widgets.nattable.data.ListDataProvider;
 import org.eclipse.nebula.widgets.nattable.data.ReflectiveColumnPropertyAccessor;
-import org.eclipse.nebula.widgets.nattable.dataset.person.Person;
 import org.eclipse.nebula.widgets.nattable.dataset.person.PersonService;
 import org.eclipse.nebula.widgets.nattable.examples.e4.AbstractE4NatExamplePart;
 import org.eclipse.nebula.widgets.nattable.grid.GridRegion;
@@ -75,7 +74,7 @@ public class MenuExample extends AbstractE4NatExamplePart {
         IDataProvider bodyDataProvider =
                 new ListDataProvider<>(
                         PersonService.getPersons(10),
-                        new ReflectiveColumnPropertyAccessor<Person>(propertyNames));
+                        new ReflectiveColumnPropertyAccessor<>(propertyNames));
 
         DefaultGridLayer gridLayer =
                 new DefaultGridLayer(bodyDataProvider,
@@ -103,7 +102,7 @@ public class MenuExample extends AbstractE4NatExamplePart {
                 // and register the DisposeListener
                 new PopupMenuBuilder(natTable, e4Menu)
                         .withInspectLabelsMenuItem()
-                        .build();
+                        .build(true);
 
                 // register the UI binding
                 uiBindingRegistry.registerMouseDownBinding(

--- a/org.eclipse.nebula.widgets.nattable.examples/src/org/eclipse/nebula/widgets/nattable/examples/_800_Integration/_818_SortableAllFilterPerformanceColumnGroupExample.java
+++ b/org.eclipse.nebula.widgets.nattable.examples/src/org/eclipse/nebula/widgets/nattable/examples/_800_Integration/_818_SortableAllFilterPerformanceColumnGroupExample.java
@@ -783,6 +783,8 @@ public class _818_SortableAllFilterPerformanceColumnGroupExample extends Abstrac
 
         private final SelectionLayer selectionLayer;
 
+        private final FreezeLayer freezeLayer;
+
         public BodyLayerStack(List<T> values, IColumnPropertyAccessor<T> columnPropertyAccessor) {
             // wrapping of the list to show into GlazedLists
             // see http://publicobject.com/glazedlists/ for further information
@@ -813,9 +815,9 @@ public class _818_SortableAllFilterPerformanceColumnGroupExample extends Abstrac
             this.selectionLayer = new SelectionLayer(columnGroupExpandCollapseLayer);
             ViewportLayer viewportLayer = new ViewportLayer(this.selectionLayer);
 
-            FreezeLayer freezeLayer = new FreezeLayer(this.selectionLayer);
+            this.freezeLayer = new FreezeLayer(this.selectionLayer);
             CompositeFreezeLayer compositeFreezeLayer =
-                    new CompositeFreezeLayer(freezeLayer, viewportLayer, this.selectionLayer);
+                    new CompositeFreezeLayer(this.freezeLayer, viewportLayer, this.selectionLayer);
 
             setUnderlyingLayer(compositeFreezeLayer);
         }
@@ -1617,7 +1619,17 @@ public class _818_SortableAllFilterPerformanceColumnGroupExample extends Abstrac
                         }
                     })
                     .withInspectLabelsMenuItem()
-                    .build();
+                    .withSubMenu("Freeze")
+                    .withFreezeColumnMenuItem()
+                    .withVisibleState(PopupMenuBuilder.FREEZE_COLUMN_MENU_ITEM_ID, natEventData -> !bodyLayerStack.freezeLayer.isFrozen())
+                    .withFreezeRowMenuItem()
+                    .withVisibleState(PopupMenuBuilder.FREEZE_ROW_MENU_ITEM_ID, natEventData -> !bodyLayerStack.freezeLayer.isFrozen())
+                    .withFreezePositionMenuItem(true)
+                    .withVisibleState(PopupMenuBuilder.FREEZE_POSITION_MENU_ITEM_ID, natEventData -> !bodyLayerStack.freezeLayer.isFrozen())
+                    .withUnfreezeMenuItem()
+                    .withVisibleState(PopupMenuBuilder.UNFREEZE_MENU_ITEM_ID, natEventData -> bodyLayerStack.freezeLayer.isFrozen())
+                    .buildSubMenu()
+                    .build(true);
         }
 
         @Override


### PR DESCRIPTION
Added `PopupMenuBuilder#withSubMenu()` methods for adding sub menus to a context menu. These methods create a new `PopupMenuBuilder` for the submenu, that needs to be closed via the new `#buildSubMenu()` method to be able to follow the builder pattern.

Additionally there is a new `#builder(boolean)` method that allows to specify if the internal `MenuManager` should be disposed or not. This is necessary, because the `MenuManager` itself has a `MenuItem` if it is used for a sub menu, that otherwise isn't disposed and might lead to a resource leak.
By default only the `Menu` is disposed, to be backwards compatible in case a custom `MenuManager` is used for creating the context menu, that should be reused in other scenarios. If we would always dispose the `MenuManager` internally, it could break existing setups.