### PR TITLE
Fixes #47 - Single click action sometimes triggered twice

### DIFF
--- a/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/ui/action/DragModeEventHandler.java
+++ b/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/ui/action/DragModeEventHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2020 Original authors and others.
+ * Copyright (c) 2012, 2024 Original authors and others.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -74,10 +74,10 @@ public class DragModeEventHandler extends AbstractModeEventHandler {
             // case the registered click operation is executed also.
             if (!this.realDrag
                     && MouseEventHelper.eventOnSameCell(this.natTable, this.mouseDownEvent, event)) {
-                this.parentModeEventHandler.mouseUp(event);
                 // switching back to the parent mode to correctly handle
                 // possible double clicks
                 switchMode(this.parentModeEventHandler);
+                this.parentModeEventHandler.mouseUp(event);
             } else {
                 switchMode(Mode.NORMAL_MODE);
             }


### PR DESCRIPTION
It looks like the fix is to first change the mode back to `MouseModeEventHandler` and then trigger `mouseUp()` in the `parentModeEventHandler`