### PR TITLE
Fixes #17 - Activate multi-edit if not all cells are editable

### DIFF
--- a/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/edit/command/EditSelectionCommandHandler.java
+++ b/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/edit/command/EditSelectionCommandHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2023 Original authors and others.
+ * Copyright (c) 2012, 2024 Original authors and others.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -107,7 +107,7 @@ public class EditSelectionCommandHandler extends AbstractLayerCommandHandler<Edi
             // determine the initial value
             Object initialEditValue = initialValue;
             if (initialValue == null
-                    && EditUtils.isValueSame(this.selectionLayer, this.upperLayer)) {
+                    && EditUtils.isValueSame(selectedCells)) {
                 ILayerCell cell = selectedCells.iterator().next();
                 initialEditValue = this.selectionLayer.getDataValueByPosition(
                         cell.getColumnPosition(),


### PR DESCRIPTION
Corrected the call to EditUtils#isValueSame() to use the retrieved cells instead of calculating them again. This way the checkbox multi-edit behavior also works correctly.