### PR TITLE
Impl #55 - [TextPainter] add option to disable word cutting

### DIFF
--- a/org.eclipse.nebula.widgets.nattable.core/.settings/.api_filters
+++ b/org.eclipse.nebula.widgets.nattable.core/.settings/.api_filters
@@ -8,6 +8,14 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="src/org/eclipse/nebula/widgets/nattable/painter/cell/AbstractTextPainter.java" type="org.eclipse.nebula.widgets.nattable.painter.cell.AbstractTextPainter">
+        <filter id="336658481">
+            <message_arguments>
+                <message_argument value="org.eclipse.nebula.widgets.nattable.painter.cell.AbstractTextPainter"/>
+                <message_argument value="NEW_LINE_PATTERN"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="src/org/eclipse/nebula/widgets/nattable/ui/menu/PopupMenuBuilder.java" type="org.eclipse.nebula.widgets.nattable.ui.menu.PopupMenuBuilder">
         <filter id="336658481">
             <message_arguments>


### PR DESCRIPTION
Added the `cutText` configuration with corresponding getter and setter methods, which is evaluated in `modifyTextToDisplay()`. Additionally added a minor performance improvement, by pre compiling the `NEW_LINE_REGEX` to a `Pattern` to avoid the constant Pattern compile process on `String#split`. 