### PR TITLE
Fixes #71 - [Grouping] Creating a group in frozen state hides column

### DIFF
--- a/org.eclipse.nebula.widgets.nattable.core.test/src/org/eclipse/nebula/widgets/nattable/freeze/CompositeFreezeLayerHideShowTest.java
+++ b/org.eclipse.nebula.widgets.nattable.core.test/src/org/eclipse/nebula/widgets/nattable/freeze/CompositeFreezeLayerHideShowTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2020 Original authors and others.
+ * Copyright (c) 2012, 2024 Original authors and others.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -38,6 +38,9 @@ import org.eclipse.nebula.widgets.nattable.layer.command.ConfigureScalingCommand
 import org.eclipse.nebula.widgets.nattable.layer.event.RowDeleteEvent;
 import org.eclipse.nebula.widgets.nattable.layer.event.RowInsertEvent;
 import org.eclipse.nebula.widgets.nattable.reorder.ColumnReorderLayer;
+import org.eclipse.nebula.widgets.nattable.reorder.RowReorderLayer;
+import org.eclipse.nebula.widgets.nattable.reorder.command.MultiColumnReorderCommand;
+import org.eclipse.nebula.widgets.nattable.reorder.command.MultiRowReorderCommand;
 import org.eclipse.nebula.widgets.nattable.selection.SelectionLayer;
 import org.eclipse.nebula.widgets.nattable.util.IClientAreaProvider;
 import org.eclipse.nebula.widgets.nattable.viewport.ViewportLayer;
@@ -75,7 +78,8 @@ public class CompositeFreezeLayerHideShowTest {
     };
 
     private DataLayer dataLayer;
-    private ColumnReorderLayer reorderLayer;
+    private ColumnReorderLayer columnReorderLayer;
+    private RowReorderLayer rowReorderLayer;
     private RowHideShowLayer rowHideShowLayer;
     private ColumnHideShowLayer columnHideShowLayer;
     private SelectionLayer selectionLayer;
@@ -86,8 +90,9 @@ public class CompositeFreezeLayerHideShowTest {
     @BeforeEach
     public void setup() {
         this.dataLayer = new DataLayer(this.testDataProvider);
-        this.reorderLayer = new ColumnReorderLayer(this.dataLayer);
-        this.rowHideShowLayer = new RowHideShowLayer(this.reorderLayer);
+        this.columnReorderLayer = new ColumnReorderLayer(this.dataLayer);
+        this.rowReorderLayer = new RowReorderLayer(this.columnReorderLayer);
+        this.rowHideShowLayer = new RowHideShowLayer(this.rowReorderLayer);
         this.columnHideShowLayer = new ColumnHideShowLayer(this.rowHideShowLayer);
         this.selectionLayer = new SelectionLayer(this.columnHideShowLayer);
         this.viewportLayer = new ViewportLayer(this.selectionLayer);
@@ -1709,6 +1714,80 @@ public class CompositeFreezeLayerHideShowTest {
 
         assertEquals(0, this.viewportLayer.getMinimumOrigin().getX());
         assertEquals(60, this.viewportLayer.getMinimumOrigin().getY());
+
+        reset();
+    }
+
+    @Test
+    public void testMultiColumnReorderBothRegions() {
+        this.compositeFreezeLayer.doCommand(
+                new FreezeColumnCommand(this.compositeFreezeLayer, 0));
+
+        assertEquals(1, this.freezeLayer.getColumnCount());
+        assertEquals(0, this.freezeLayer.getRowCount());
+        assertEquals(0, this.freezeLayer.getBottomRightPosition().columnPosition);
+        assertEquals(-1, this.freezeLayer.getBottomRightPosition().rowPosition);
+
+        assertEquals(4, this.viewportLayer.getColumnCount());
+        assertEquals(5, this.viewportLayer.getRowCount());
+        assertEquals(1, this.viewportLayer.getMinimumOriginColumnPosition());
+        assertEquals(0, this.viewportLayer.getMinimumOriginRowPosition());
+        assertEquals(100, this.viewportLayer.getMinimumOrigin().getX());
+        assertEquals(0, this.viewportLayer.getMinimumOrigin().getY());
+
+        // multi reorder so that column 0 and column 3 are next to each other
+        // while 0 stays in frozen area and 3 stays in non-frozen area
+        this.compositeFreezeLayer.doCommand(
+                new MultiColumnReorderCommand(this.compositeFreezeLayer, new int[] { 0, 3 }, 0));
+
+        assertEquals(1, this.freezeLayer.getColumnCount());
+        assertEquals(0, this.freezeLayer.getRowCount());
+        assertEquals(0, this.freezeLayer.getBottomRightPosition().columnPosition);
+        assertEquals(-1, this.freezeLayer.getBottomRightPosition().rowPosition);
+
+        assertEquals(4, this.viewportLayer.getColumnCount());
+        assertEquals(5, this.viewportLayer.getRowCount());
+        assertEquals(1, this.viewportLayer.getMinimumOriginColumnPosition());
+        assertEquals(0, this.viewportLayer.getMinimumOriginRowPosition());
+        assertEquals(100, this.viewportLayer.getMinimumOrigin().getX());
+        assertEquals(0, this.viewportLayer.getMinimumOrigin().getY());
+
+        reset();
+    }
+
+    @Test
+    public void testMultiRowReorderBothRegions() {
+        this.compositeFreezeLayer.doCommand(
+                new FreezeRowCommand(this.compositeFreezeLayer, 0));
+
+        assertEquals(0, this.freezeLayer.getColumnCount());
+        assertEquals(1, this.freezeLayer.getRowCount());
+        assertEquals(-1, this.freezeLayer.getBottomRightPosition().columnPosition);
+        assertEquals(0, this.freezeLayer.getBottomRightPosition().rowPosition);
+
+        assertEquals(5, this.viewportLayer.getColumnCount());
+        assertEquals(4, this.viewportLayer.getRowCount());
+        assertEquals(0, this.viewportLayer.getMinimumOriginColumnPosition());
+        assertEquals(1, this.viewportLayer.getMinimumOriginRowPosition());
+        assertEquals(0, this.viewportLayer.getMinimumOrigin().getX());
+        assertEquals(20, this.viewportLayer.getMinimumOrigin().getY());
+
+        // multi reorder so that row 0 and row 3 are next to each other
+        // while 0 stays in frozen area and 3 stays in non-frozen area
+        this.compositeFreezeLayer.doCommand(
+                new MultiRowReorderCommand(this.compositeFreezeLayer, new int[] { 0, 3 }, 0));
+
+        assertEquals(0, this.freezeLayer.getColumnCount());
+        assertEquals(1, this.freezeLayer.getRowCount());
+        assertEquals(-1, this.freezeLayer.getBottomRightPosition().columnPosition);
+        assertEquals(0, this.freezeLayer.getBottomRightPosition().rowPosition);
+
+        assertEquals(5, this.viewportLayer.getColumnCount());
+        assertEquals(4, this.viewportLayer.getRowCount());
+        assertEquals(0, this.viewportLayer.getMinimumOriginColumnPosition());
+        assertEquals(1, this.viewportLayer.getMinimumOriginRowPosition());
+        assertEquals(0, this.viewportLayer.getMinimumOrigin().getX());
+        assertEquals(20, this.viewportLayer.getMinimumOrigin().getY());
 
         reset();
     }

--- a/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/viewport/event/ViewportEventHandler.java
+++ b/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/viewport/event/ViewportEventHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2020 Original authors and others.
+ * Copyright (c) 2012, 2024 Original authors and others.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -43,8 +43,7 @@ public class ViewportEventHandler implements ILayerEventHandler<IStructuralChang
             this.viewportLayer.invalidateHorizontalStructure();
 
             int columnOffset = 0;
-            int minimumOriginColumnPosition = this.viewportLayer
-                    .getMinimumOriginColumnPosition();
+            int minimumOriginColumnPosition = this.viewportLayer.getMinimumOriginColumnPosition();
 
             Collection<StructuralDiff> columnDiffs = event.getColumnDiffs();
             if (columnDiffs != null) {
@@ -55,24 +54,23 @@ public class ViewportEventHandler implements ILayerEventHandler<IStructuralChang
                     // was hidden, so we try to determine the correct value now
                     // if it is shown again
                     minimumOriginColumnPosition = scrollableLayer
-                            .getColumnPositionByX(this.viewportLayer
-                                    .getMinimumOrigin().getX());
+                            .getColumnPositionByX(this.viewportLayer.getMinimumOrigin().getX());
                 }
                 for (StructuralDiff columnDiff : columnDiffs) {
                     DiffTypeEnum diffType = columnDiff.getDiffType();
                     if (diffType == DiffTypeEnum.ADD) {
-                        Range afterPositionRange = columnDiff
-                                .getAfterPositionRange();
+                        Range afterPositionRange = columnDiff.getAfterPositionRange();
                         if (minimumOriginColumnPosition > 0) {
+                            int mocp = minimumOriginColumnPosition;
                             for (int i = afterPositionRange.start; i < afterPositionRange.end; i++) {
-                                if (i < minimumOriginColumnPosition) {
-                                    minimumOriginColumnPosition++;
+                                if (i < mocp) {
+                                    mocp++;
+                                    columnOffset += 1;
                                 }
                             }
                         }
                     } else if (diffType == DiffTypeEnum.DELETE) {
-                        Range beforePositionRange = columnDiff
-                                .getBeforePositionRange();
+                        Range beforePositionRange = columnDiff.getBeforePositionRange();
                         if (minimumOriginColumnPosition > 0) {
                             for (int i = beforePositionRange.start; i < beforePositionRange.end; i++) {
                                 if (i < minimumOriginColumnPosition) {
@@ -84,8 +82,7 @@ public class ViewportEventHandler implements ILayerEventHandler<IStructuralChang
                 }
             }
 
-            int minimumOriginColumn = minimumOriginColumnPosition
-                    + columnOffset;
+            int minimumOriginColumn = minimumOriginColumnPosition + columnOffset;
 
             // in case of split viewports we use the min column position instead
             // of the calculated value
@@ -97,18 +94,15 @@ public class ViewportEventHandler implements ILayerEventHandler<IStructuralChang
             // viewport is moved
             // to the frozen region, the minimum origin need to be updated in
             // another way
-            int startX = scrollableLayer
-                    .getStartXOfColumnPosition(minimumOriginColumn);
+            int startX = scrollableLayer.getStartXOfColumnPosition(minimumOriginColumn);
             if (startX < 0 && minimumOriginColumnPosition > 0) {
                 int columnCount = scrollableLayer.getColumnCount();
                 if (columnCount == 0) {
                     // special case when all columns are hidden
                     startX = 0;
                 } else {
-                    startX = scrollableLayer
-                            .getStartXOfColumnPosition(columnCount - 1)
-                            + scrollableLayer
-                                    .getColumnWidthByPosition(columnCount - 1);
+                    startX = scrollableLayer.getStartXOfColumnPosition(columnCount - 1)
+                            + scrollableLayer.getColumnWidthByPosition(columnCount - 1);
                 }
             }
 
@@ -119,8 +113,7 @@ public class ViewportEventHandler implements ILayerEventHandler<IStructuralChang
             this.viewportLayer.invalidateVerticalStructure();
 
             int rowOffset = 0;
-            int minimumOriginRowPosition = this.viewportLayer
-                    .getMinimumOriginRowPosition();
+            int minimumOriginRowPosition = this.viewportLayer.getMinimumOriginRowPosition();
 
             Collection<StructuralDiff> rowDiffs = event.getRowDiffs();
             if (rowDiffs != null) {
@@ -131,24 +124,23 @@ public class ViewportEventHandler implements ILayerEventHandler<IStructuralChang
                     // was hidden, so we try to determine the correct value now
                     // if it is shown again
                     minimumOriginRowPosition = scrollableLayer
-                            .getRowPositionByY(this.viewportLayer.getMinimumOrigin()
-                                    .getY());
+                            .getRowPositionByY(this.viewportLayer.getMinimumOrigin().getY());
                 }
                 for (StructuralDiff rowDiff : rowDiffs) {
                     DiffTypeEnum diffType = rowDiff.getDiffType();
                     if (diffType == DiffTypeEnum.ADD) {
-                        Range afterPositionRange = rowDiff
-                                .getAfterPositionRange();
+                        Range afterPositionRange = rowDiff.getAfterPositionRange();
                         if (minimumOriginRowPosition > 0) {
+                            int morp = minimumOriginRowPosition;
                             for (int i = afterPositionRange.start; i < afterPositionRange.end; i++) {
-                                if (i < minimumOriginRowPosition) {
-                                    minimumOriginRowPosition++;
+                                if (i < morp) {
+                                    morp++;
+                                    rowOffset += 1;
                                 }
                             }
                         }
                     } else if (diffType == DiffTypeEnum.DELETE) {
-                        Range beforePositionRange = rowDiff
-                                .getBeforePositionRange();
+                        Range beforePositionRange = rowDiff.getBeforePositionRange();
                         if (minimumOriginRowPosition > 0) {
                             for (int i = beforePositionRange.start; i < beforePositionRange.end; i++) {
                                 if (i < minimumOriginRowPosition) {
@@ -172,18 +164,15 @@ public class ViewportEventHandler implements ILayerEventHandler<IStructuralChang
             // viewport is moved
             // to the frozen region, the minimum origin need to be updated in
             // another way
-            int startY = scrollableLayer
-                    .getStartYOfRowPosition(minimumOriginRow);
+            int startY = scrollableLayer.getStartYOfRowPosition(minimumOriginRow);
             if (startY < 0 && minimumOriginRowPosition > 0) {
                 int rowCount = scrollableLayer.getRowCount();
                 if (rowCount == 0) {
                     // special case when all rows are hidden
                     startY = 0;
                 } else {
-                    startY = scrollableLayer
-                            .getStartYOfRowPosition(rowCount - 1)
-                            + scrollableLayer
-                                    .getRowHeightByPosition(rowCount - 1);
+                    startY = scrollableLayer.getStartYOfRowPosition(rowCount - 1)
+                            + scrollableLayer.getRowHeightByPosition(rowCount - 1);
                 }
             }
             this.viewportLayer.setMinimumOriginY(startY);


### PR DESCRIPTION
The reason for the issue is an incorrect update of the minimumOriginXxxPosition while processing the structural change event. As the creation of a group of non-consecutive positions results in a multi reorder operation, the processing struggles with the update of the minimum origin position. 

The check whether a change should be considered or not needs the update while processing, but the real change of data needs to be performed only at the end. Otherwise the status gets inconsistent.