### PR TITLE
Issue #145 - Modifications to support NatTable in RAP

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
   <extension>
     <groupId>org.eclipse.tycho</groupId>
     <artifactId>tycho-build</artifactId>
-    <version>4.0.10</version>
+    <version>4.0.12</version>
   </extension>
 </extensions>

--- a/org.eclipse.nebula.widgets.nattable.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.nebula.widgets.nattable.core/META-INF/MANIFEST.MF
@@ -222,10 +222,12 @@ Import-Package: org.eclipse.collections.api;version="10.1.0",
  org.eclipse.swt.events,
  org.eclipse.swt.graphics,
  org.eclipse.swt.layout,
- org.eclipse.swt.printing,
- org.eclipse.swt.program,
+ org.eclipse.swt.printing;resolution:=optional,
+ org.eclipse.swt.program;resolution:=optional,
  org.eclipse.swt.widgets,
+ org.osgi.framework;version="[1.10.0,2.0.0)",
  org.slf4j;version="1.7.2"
 Bundle-Vendor: Eclipse Nebula NatTable
 Require-Bundle: org.eclipse.equinox.common
 Automatic-Module-Name: org.eclipse.nebula.widgets.nattable.core
+Bundle-Activator: org.eclipse.nebula.widgets.nattable.Activator

--- a/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/Activator.java
+++ b/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/Activator.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Dirk Fauth and others.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Dirk Fauth <dirk.fauth@googlemail.com> - initial API and implementation
+ ******************************************************************************/
+package org.eclipse.nebula.widgets.nattable;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+
+/**
+ * Activator that will call the RAPInitializer if available. Needed in an
+ * activator to ensure that the RAPInitializer is called before any NatTable
+ * class is loaded.
+ *
+ * @since 2.6
+ */
+public class Activator implements BundleActivator {
+
+    @Override
+    public void start(BundleContext context) {
+        try {
+            Class<?> forName = getClass().getClassLoader().loadClass("org.eclipse.nebula.widgets.nattable.RAPInitializer"); //$NON-NLS-1$
+            if (forName != null) {
+                forName.getMethod("initialize").invoke(null); //$NON-NLS-1$
+            }
+        } catch (ClassNotFoundException | IllegalAccessException | IllegalArgumentException | InvocationTargetException | NoSuchMethodException | SecurityException e) {
+            // do nothing, if not running in RAP there is no initializer
+        }
+    }
+
+    @Override
+    public void stop(BundleContext context) throws Exception {
+    }
+}

--- a/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/NatTable.java
+++ b/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/NatTable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2023 Original authors and others.
+ * Copyright (c) 2012, 2025 Original authors and others.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -72,6 +72,7 @@ import org.eclipse.nebula.widgets.nattable.ui.mode.Mode;
 import org.eclipse.nebula.widgets.nattable.ui.mode.ModeSupport;
 import org.eclipse.nebula.widgets.nattable.util.GUIHelper;
 import org.eclipse.nebula.widgets.nattable.util.IClientAreaProvider;
+import org.eclipse.nebula.widgets.nattable.util.PlatformHelper;
 import org.eclipse.nebula.widgets.nattable.viewport.command.RecalculateScrollBarsCommand;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.BusyIndicator;
@@ -281,14 +282,18 @@ public class NatTable extends Canvas implements ILayer, PaintListener, IClientAr
         this.conflaterChain.add(getVisualChangeEventConflater());
         this.conflaterChain.start();
 
-        parent.addListener(SWT.Resize, this.closeEditorOnParentResize);
+        if (!PlatformHelper.isRAP()) {
+            parent.addListener(SWT.Resize, this.closeEditorOnParentResize);
+        }
 
         addDisposeListener(e -> {
             doCommand(new DisposeResourcesCommand());
             NatTable.this.conflaterChain.stop();
             layer.dispose();
 
-            parent.removeListener(SWT.Resize, NatTable.this.closeEditorOnParentResize);
+            if (!PlatformHelper.isRAP()) {
+                parent.removeListener(SWT.Resize, NatTable.this.closeEditorOnParentResize);
+            }
         });
     }
 

--- a/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/edit/editor/AbstractCellEditor.java
+++ b/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/edit/editor/AbstractCellEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2020 Original authors and others.
+ * Copyright (c) 2012, 2025 Original authors and others.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -393,16 +393,19 @@ public abstract class AbstractCellEditor implements ICellEditor {
 
     @Override
     public void close() {
-        this.closed = true;
-        if (this.parent != null && !this.parent.isDisposed()) {
-            this.parent.forceFocus();
-        }
+        if (!this.closed) {
+            this.closed = true;
 
-        removeEditorControlListeners();
+            removeEditorControlListeners();
 
-        Control editorControl = getEditorControl();
-        if (editorControl != null && !editorControl.isDisposed()) {
-            editorControl.dispose();
+            if (this.parent != null && !this.parent.isDisposed()) {
+                this.parent.forceFocus();
+            }
+
+            Control editorControl = getEditorControl();
+            if (editorControl != null && !editorControl.isDisposed()) {
+                editorControl.dispose();
+            }
         }
     }
 

--- a/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/edit/editor/TableCellEditor.java
+++ b/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/edit/editor/TableCellEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2024 Dirk Fauth and others.
+ * Copyright (c) 2013, 2025 Dirk Fauth and others.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -41,6 +41,7 @@ import org.eclipse.nebula.widgets.nattable.style.HorizontalAlignmentEnum;
 import org.eclipse.nebula.widgets.nattable.style.IStyle;
 import org.eclipse.nebula.widgets.nattable.style.Style;
 import org.eclipse.nebula.widgets.nattable.util.GUIHelper;
+import org.eclipse.nebula.widgets.nattable.util.PlatformHelper;
 import org.eclipse.nebula.widgets.nattable.widget.EditModeEnum;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.FocusEvent;
@@ -434,6 +435,12 @@ public class TableCellEditor extends AbstractCellEditor {
      *         results in using the OS default height based on the font.
      */
     public int getFixedSubCellHeight() {
+        if (PlatformHelper.isRAP()) {
+            // RAP does not know the SWT.MeasureItem event
+            // it is therefore only possible to use the the default height based
+            // on the font
+            return -1;
+        }
         return this.fixedSubCellHeight;
     }
 

--- a/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/edit/editor/TextCellEditor.java
+++ b/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/edit/editor/TextCellEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2024 Original authors and others.
+ * Copyright (c) 2012, 2025 Original authors and others.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -28,6 +28,7 @@ import org.eclipse.nebula.widgets.nattable.style.CellStyleAttributes;
 import org.eclipse.nebula.widgets.nattable.style.DisplayMode;
 import org.eclipse.nebula.widgets.nattable.style.HorizontalAlignmentEnum;
 import org.eclipse.nebula.widgets.nattable.style.IStyle;
+import org.eclipse.nebula.widgets.nattable.util.PlatformHelper;
 import org.eclipse.nebula.widgets.nattable.widget.EditModeEnum;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.KeyAdapter;
@@ -384,6 +385,13 @@ public class TextCellEditor extends AbstractCellEditor {
                         if (isCommitWithCtrlKey()) {
                             commit = (event.stateMask == SWT.MOD1) ? true : false;
                         }
+
+                        // in case of RAP we need to avoid the commit in an edit
+                        // dialog, as the commit from the dialog otherwise fails
+                        if (PlatformHelper.isRAP() && TextCellEditor.this.editMode == EditModeEnum.DIALOG) {
+                            commit = false;
+                        }
+
                         MoveDirectionEnum move = MoveDirectionEnum.NONE;
                         if (TextCellEditor.this.moveSelectionOnEnter
                                 && TextCellEditor.this.editMode == EditModeEnum.INLINE) {

--- a/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/edit/gui/FileDialogCellEditor.java
+++ b/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/edit/gui/FileDialogCellEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2020 Dirk Fauth and others.
+ * Copyright (c) 2013, 2025 Dirk Fauth and others.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,6 +14,7 @@ package org.eclipse.nebula.widgets.nattable.edit.gui;
 
 import org.eclipse.jface.window.Window;
 import org.eclipse.nebula.widgets.nattable.selection.SelectionLayer.MoveDirectionEnum;
+import org.eclipse.nebula.widgets.nattable.util.PlatformHelper;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.FileDialog;
 
@@ -34,13 +35,6 @@ public class FileDialogCellEditor extends AbstractDialogCellEditor {
      */
     private boolean closed = false;
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * org.eclipse.nebula.widgets.nattable.edit.editor.AbstractDialogCellEditor
-     * #open()
-     */
     @Override
     public int open() {
         this.selectedFile = getDialogInstance().open();
@@ -54,76 +48,33 @@ public class FileDialogCellEditor extends AbstractDialogCellEditor {
         }
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * org.eclipse.nebula.widgets.nattable.edit.editor.AbstractDialogCellEditor
-     * #createDialogInstance()
-     */
     @Override
     public FileDialog createDialogInstance() {
         this.closed = false;
         return new FileDialog(this.parent.getShell(), SWT.OPEN);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * org.eclipse.nebula.widgets.nattable.edit.editor.AbstractDialogCellEditor
-     * #getDialogInstance()
-     */
     @Override
     public FileDialog getDialogInstance() {
         return (FileDialog) this.dialog;
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * org.eclipse.nebula.widgets.nattable.edit.editor.AbstractDialogCellEditor
-     * #getEditorValue()
-     */
     @Override
     public Object getEditorValue() {
         return this.selectedFile;
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * org.eclipse.nebula.widgets.nattable.edit.editor.AbstractDialogCellEditor
-     * #setEditorValue(java.lang.Object)
-     */
     @Override
     public void setEditorValue(Object value) {
-        getDialogInstance()
-                .setFileName(value != null ? value.toString() : null);
+        PlatformHelper.callSetter(getDialogInstance(), "setFileName", String.class, value != null ? value.toString() : null); //$NON-NLS-1$
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * org.eclipse.nebula.widgets.nattable.edit.editor.AbstractDialogCellEditor
-     * #close()
-     */
     @Override
     public void close() {
         // as the FileDialog does not support a programmatically way of closing,
         // this method is forced to do nothing
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * org.eclipse.nebula.widgets.nattable.edit.editor.AbstractDialogCellEditor
-     * #isClosed()
-     */
     @Override
     public boolean isClosed() {
         return this.closed;

--- a/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/export/FileOutputStreamProvider.java
+++ b/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/export/FileOutputStreamProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2023 Original authors and others.
+ * Copyright (c) 2012, 2025 Original authors and others.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,10 +14,14 @@
 package org.eclipse.nebula.widgets.nattable.export;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import org.eclipse.nebula.widgets.nattable.Messages;
+import org.eclipse.nebula.widgets.nattable.util.PlatformHelper;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.FileDialog;
 import org.eclipse.swt.widgets.Shell;
@@ -56,39 +60,55 @@ public class FileOutputStreamProvider implements IOutputStreamProvider {
             throw new IllegalArgumentException("Shell can not be null"); //$NON-NLS-1$
         }
 
-        // ensure the FileDialog is opened in the UI thread
-        shell.getDisplay().syncExec(() -> {
+        if (!PlatformHelper.isRAP()) {
+            // ensure the FileDialog is opened in the UI thread
+            shell.getDisplay().syncExec(() -> {
 
-            FileDialog dialog = new FileDialog(shell, SWT.SAVE);
+                FileDialog dialog = new FileDialog(shell, SWT.SAVE);
 
-            String filterPath;
-            String relativeFileName;
+                String filterPath;
+                String relativeFileName;
 
-            int lastIndexOfFileSeparator = this.defaultFileName.lastIndexOf(File.separator);
-            if (lastIndexOfFileSeparator >= 0) {
-                filterPath = this.defaultFileName.substring(0, lastIndexOfFileSeparator);
-                relativeFileName = this.defaultFileName.substring(lastIndexOfFileSeparator + 1);
-            } else {
-                filterPath = "/"; //$NON-NLS-1$
-                relativeFileName = this.defaultFileName;
+                int lastIndexOfFileSeparator = this.defaultFileName.lastIndexOf(File.separator);
+                if (lastIndexOfFileSeparator >= 0) {
+                    filterPath = this.defaultFileName.substring(0, lastIndexOfFileSeparator);
+                    relativeFileName = this.defaultFileName.substring(lastIndexOfFileSeparator + 1);
+                } else {
+                    filterPath = "/"; //$NON-NLS-1$
+                    relativeFileName = this.defaultFileName;
+                }
+
+                PlatformHelper.callSetter(dialog, "setFilterPath", String.class, filterPath); //$NON-NLS-1$
+                PlatformHelper.callSetter(dialog, "setOverwrite", boolean.class, true); //$NON-NLS-1$
+
+                PlatformHelper.callSetter(dialog, "setFileName", String.class, relativeFileName); //$NON-NLS-1$
+                PlatformHelper.callSetter(dialog, "setFilterNames", String[].class, this.defaultFilterNames); //$NON-NLS-1$
+                dialog.setFilterExtensions(this.defaultFilterExtensions);
+                this.currentFileName = dialog.open();
+
+                // reset the extension filter index each time the FileDialog is
+                // opened
+                // to avoid the case that if the dialog is cancelled, the old
+                // value
+                // index could be accidentally reused
+                this.extFilterIndex = -1;
+
+                Object filterIndex = PlatformHelper.callGetter(dialog, "getFilterIndex"); //$NON-NLS-1$
+                if (filterIndex != null) {
+                    this.extFilterIndex = (int) filterIndex;
+                }
+            });
+        } else {
+            // in RAP we simply generate the file in a temporary directory with
+            // the default file name
+            try {
+                Path tempDirectory = Files.createTempDirectory("nattable_export_"); //$NON-NLS-1$
+                Path exportFile = tempDirectory.resolve(this.defaultFileName);
+                this.currentFileName = exportFile.toString();
+            } catch (IOException e) {
+                throw new IllegalStateException("Failed to write the export to a temporary directory", e); //$NON-NLS-1$
             }
-
-            dialog.setFilterPath(filterPath);
-            dialog.setOverwrite(true);
-
-            dialog.setFileName(relativeFileName);
-            dialog.setFilterNames(this.defaultFilterNames);
-            dialog.setFilterExtensions(this.defaultFilterExtensions);
-            this.currentFileName = dialog.open();
-
-            // reset the extension filter index each time the FileDialog is
-            // opened
-            // to avoid the case that if the dialog is cancelled, the old value
-            // index could be accidentally reused
-            this.extFilterIndex = -1;
-
-            this.extFilterIndex = dialog.getFilterIndex();
-        });
+        }
 
         if (this.currentFileName == null) {
             return null;

--- a/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/export/image/ImageExporter.java
+++ b/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/export/image/ImageExporter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 Original authors and others.
+ * Copyright (c) 2017, 2025 Original authors and others.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,6 +20,7 @@ import org.eclipse.nebula.widgets.nattable.export.FileOutputStreamProvider;
 import org.eclipse.nebula.widgets.nattable.export.IOutputStreamProvider;
 import org.eclipse.nebula.widgets.nattable.export.ITableExporter;
 import org.eclipse.nebula.widgets.nattable.layer.ILayer;
+import org.eclipse.nebula.widgets.nattable.util.PlatformHelper;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.SWTException;
 import org.eclipse.swt.graphics.GC;
@@ -120,6 +121,10 @@ public class ImageExporter implements ITableExporter {
 
         if (null == shell || null == layer || null == configRegistry) {
             throw new IllegalArgumentException("Shell, layer or configure registry must not be null"); //$NON-NLS-1$
+        }
+
+        if (PlatformHelper.isRAP()) {
+            throw new IllegalStateException("An export to image is not supported with RAP"); //$NON-NLS-1$
         }
 
         int width = layer.getWidth();

--- a/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/filterrow/FilterRowTextCellEditor.java
+++ b/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/filterrow/FilterRowTextCellEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2023 Dirk Fauth and others.
+ * Copyright (c) 2014, 2025 Dirk Fauth and others.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeUnit;
 import org.eclipse.nebula.widgets.nattable.edit.editor.TextCellEditor;
 import org.eclipse.nebula.widgets.nattable.layer.cell.ILayerCell;
 import org.eclipse.nebula.widgets.nattable.selection.SelectionLayer.MoveDirectionEnum;
+import org.eclipse.nebula.widgets.nattable.util.PlatformHelper;
 import org.eclipse.swt.events.KeyAdapter;
 import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.events.PaintEvent;
@@ -84,11 +85,11 @@ public class FilterRowTextCellEditor extends TextCellEditor {
 
             }
         };
-        parent.addPaintListener(paintListener);
+        PlatformHelper.callSetter(parent, "addPaintListener", PaintListener.class, paintListener); //$NON-NLS-1$
 
         text.addDisposeListener(e -> {
             service.shutdownNow();
-            parent.removePaintListener(paintListener);
+            PlatformHelper.callSetter(parent, "removePaintListener", PaintListener.class, paintListener); //$NON-NLS-1$
         });
 
         return text;

--- a/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/filterrow/combobox/FilterRowComboBoxCellEditor.java
+++ b/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/filterrow/combobox/FilterRowComboBoxCellEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2024 Dirk Fauth and others.
+ * Copyright (c) 2013, 2025 Dirk Fauth and others.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -233,7 +233,7 @@ public class FilterRowComboBoxCellEditor extends ComboBoxCellEditor {
         combo.addKeyListener(new KeyAdapter() {
             @Override
             public void keyPressed(KeyEvent event) {
-                if (event.keyCode == SWT.SPACE) {
+                if (event.keyCode == ' ') {
                     commit(MoveDirectionEnum.NONE,
                             (!FilterRowComboBoxCellEditor.this.multiselect
                                     && FilterRowComboBoxCellEditor.this.editMode == EditModeEnum.INLINE));

--- a/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/painter/cell/AbstractTextPainter.java
+++ b/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/painter/cell/AbstractTextPainter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2024 Original authors and others.
+ * Copyright (c) 2012, 2025 Original authors and others.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -26,9 +26,11 @@ import org.eclipse.nebula.widgets.nattable.style.CellStyleAttributes;
 import org.eclipse.nebula.widgets.nattable.style.IStyle;
 import org.eclipse.nebula.widgets.nattable.style.TextDecorationEnum;
 import org.eclipse.nebula.widgets.nattable.util.GUIHelper;
+import org.eclipse.nebula.widgets.nattable.util.PlatformHelper;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.FontData;
+import org.eclipse.swt.graphics.FontMetrics;
 import org.eclipse.swt.graphics.GC;
 
 /**
@@ -752,18 +754,25 @@ public abstract class AbstractTextPainter extends BackgroundPainter {
         if ((ul || st) && length > 0) {
             // check and draw underline and strikethrough separately
             // so it is possible to combine both
+            FontMetrics metrics = gc.getFontMetrics();
             if (ul) {
                 // y = start y of text + font height - half of the font
                 // descent so the underline is between baseline and bottom
-                int underlineY = y + fontHeight - (gc.getFontMetrics().getDescent() / 2);
-                gc.drawLine(x, underlineY, x + length, underlineY);
+                Object descent = PlatformHelper.callGetter(metrics, "getDescent"); //$NON-NLS-1$
+                if (descent != null) {
+                    int underlineY = y + fontHeight - (((int) descent) / 2);
+                    gc.drawLine(x, underlineY, x + length, underlineY);
+                }
             }
 
             if (st) {
                 // y = start y of text + half of font height + ascent
                 // this way lower case characters are also strikethrough
-                int strikeY = y + (fontHeight / 2) + (gc.getFontMetrics().getLeading() / 2);
-                gc.drawLine(x, strikeY, x + length, strikeY);
+                Object leading = PlatformHelper.callGetter(metrics, "getLeading"); //$NON-NLS-1$
+                if (leading != null) {
+                    int strikeY = y + (fontHeight / 2) + (((int) leading) / 2);
+                    gc.drawLine(x, strikeY, x + length, strikeY);
+                }
             }
         }
     }

--- a/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/painter/cell/GraphicsUtils.java
+++ b/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/painter/cell/GraphicsUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2024 Original authors and others.
+ * Copyright (c) 2012, 2025 Original authors and others.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,9 +16,11 @@ package org.eclipse.nebula.widgets.nattable.painter.cell;
 import org.eclipse.nebula.widgets.nattable.style.BorderStyle;
 import org.eclipse.nebula.widgets.nattable.style.BorderStyle.BorderModeEnum;
 import org.eclipse.nebula.widgets.nattable.style.BorderStyle.LineStyleEnum;
+import org.eclipse.nebula.widgets.nattable.util.PlatformHelper;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
+import org.eclipse.swt.graphics.FontMetrics;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
@@ -136,26 +138,27 @@ public final class GraphicsUtils {
             // draw underline and/or strikethrough
             if (underline || strikethrough) {
                 // check and draw underline and strikethrough separately so it
-                // is
-                // possible to combine both
+                // is possible to combine both
+                FontMetrics metrics = stringGc.getFontMetrics();
                 if (underline) {
-                    // y = start y of text + font height
-                    // - half of the font descent so the underline is between
-                    // the
-                    // baseline and the bottom
-                    int underlineY = pt.y
-                            - (stringGc.getFontMetrics().getDescent() / 2);
-                    stringGc.drawLine(0, underlineY, pt.x, underlineY);
+                    // y = start y of text + font height - half of the font
+                    // descent so the underline is between the baseline and the
+                    // bottom
+                    Object descent = PlatformHelper.callGetter(metrics, "getDescent"); //$NON-NLS-1$
+                    if (descent != null) {
+                        int underlineY = pt.y - (((int) descent) / 2);
+                        stringGc.drawLine(0, underlineY, pt.x, underlineY);
+                    }
                 }
 
                 if (strikethrough) {
                     // y = start y of text + half of font height + ascent so
-                    // lower
-                    // case characters are
-                    // also strikethrough
-                    int strikeY = (pt.y / 2)
-                            + (stringGc.getFontMetrics().getLeading() / 2);
-                    stringGc.drawLine(0, strikeY, pt.x, strikeY);
+                    // lower case characters are also strikethrough
+                    Object leading = PlatformHelper.callGetter(metrics, "getLeading"); //$NON-NLS-1$
+                    if (leading != null) {
+                        int strikeY = (pt.y / 2) + (((int) leading) / 2);
+                        stringGc.drawLine(0, strikeY, pt.x, strikeY);
+                    }
                 }
             }
 

--- a/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/painter/cell/VerticalTextPainter.java
+++ b/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/painter/cell/VerticalTextPainter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2020 Original authors and others.
+ * Copyright (c) 2012, 2025 Original authors and others.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,6 +20,7 @@ import org.eclipse.nebula.widgets.nattable.resize.command.ColumnResizeCommand;
 import org.eclipse.nebula.widgets.nattable.resize.command.RowResizeCommand;
 import org.eclipse.nebula.widgets.nattable.style.CellStyleUtil;
 import org.eclipse.nebula.widgets.nattable.style.IStyle;
+import org.eclipse.nebula.widgets.nattable.util.PlatformHelper;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Rectangle;
@@ -231,7 +232,10 @@ public class VerticalTextPainter extends AbstractTextPainter {
                         int horizontalPadding = CellStyleUtil.getHorizontalAlignmentPadding(
                                 cellStyle, rectangle, contentHeight);
                         if (horizontalPadding != 0) {
-                            horizontalPadding += gc.getFontMetrics().getLeading();
+                            Object leading = PlatformHelper.callGetter(gc.getFontMetrics(), "getLeading"); //$NON-NLS-1$
+                            if (leading != null) {
+                                horizontalPadding += (int) leading;
+                            }
                         }
 
                         int xOffset = rectangle.y
@@ -288,7 +292,10 @@ public class VerticalTextPainter extends AbstractTextPainter {
 
                                 int horizontalPadding = CellStyleUtil.getHorizontalAlignmentPadding(cellStyle, rectangle, contentHeight);
                                 if (horizontalPadding != 0) {
-                                    horizontalPadding += gc.getFontMetrics().getLeading();
+                                    Object leading = PlatformHelper.callGetter(gc.getFontMetrics(), "getLeading"); //$NON-NLS-1$
+                                    if (leading != null) {
+                                        horizontalPadding += (int) leading;
+                                    }
                                 }
                                 int yOffset = -contentHeight
                                         - rectangle.y

--- a/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/print/command/PrintCommandHandler.java
+++ b/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/print/command/PrintCommandHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2020 Original authors and others.
+ * Copyright (c) 2012, 2025 Original authors and others.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,6 +16,7 @@ import org.eclipse.nebula.widgets.nattable.command.AbstractLayerCommandHandler;
 import org.eclipse.nebula.widgets.nattable.command.ILayerCommandHandler;
 import org.eclipse.nebula.widgets.nattable.layer.ILayer;
 import org.eclipse.nebula.widgets.nattable.print.LayerPrinter;
+import org.eclipse.nebula.widgets.nattable.util.PlatformHelper;
 
 /**
  * {@link ILayerCommandHandler} for handling the {@link PrintCommand}. Simply
@@ -39,7 +40,9 @@ public class PrintCommandHandler extends AbstractLayerCommandHandler<PrintComman
 
     @Override
     public boolean doCommand(PrintCommand command) {
-        new LayerPrinter(this.layer, command.getConfigRegistry()).print(command.getShell());
+        if (!PlatformHelper.isRAP()) {
+            new LayerPrinter(this.layer, command.getConfigRegistry()).print(command.getShell());
+        }
         return true;
     }
 

--- a/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/style/editor/ColorPicker.java
+++ b/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/style/editor/ColorPicker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2024 Original authors and others.
+ * Copyright (c) 2012, 2025 Original authors and others.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -18,10 +18,8 @@ import org.eclipse.swt.custom.CLabel;
 import org.eclipse.swt.events.MouseAdapter;
 import org.eclipse.swt.events.MouseEvent;
 import org.eclipse.swt.graphics.Color;
-import org.eclipse.swt.graphics.GC;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.RGB;
-import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.ColorDialog;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
@@ -36,7 +34,6 @@ import org.eclipse.swt.widgets.Shell;
 public class ColorPicker extends CLabel {
 
     private Color selectedColor;
-    private Image image;
 
     public ColorPicker(Composite parent, final Color originalColor) {
         super(parent, SWT.SHADOW_OUT);
@@ -44,7 +41,7 @@ public class ColorPicker extends CLabel {
             throw new IllegalArgumentException("null"); //$NON-NLS-1$
         }
         this.selectedColor = originalColor;
-        setImage(getColorImage(originalColor));
+        setBackground(this.selectedColor);
         addMouseListener(new MouseAdapter() {
             @Override
             public void mouseDown(MouseEvent e) {
@@ -58,22 +55,17 @@ public class ColorPicker extends CLabel {
         });
     }
 
-    private Image getColorImage(Color color) {
-        Display display = Display.getCurrent();
-        this.image = new Image(display, new Rectangle(10, 10, 70, 20));
-        GC gc = new GC(this.image);
-        try {
-            gc.setBackground(color);
-            gc.fillRectangle(this.image.getBounds());
-        } finally {
-            gc.dispose();
-        }
-        return this.image;
+    @Override
+    public Point computeSize(int wHint, int hHint, boolean changed) {
+        // return a fixed size
+        return new Point(
+                GUIHelper.convertHorizontalPixelToDpi(70),
+                GUIHelper.convertVerticalDpiToPixel(20));
     }
 
     private void update(RGB selected) {
         this.selectedColor = GUIHelper.getColor(selected);
-        setImage(getColorImage(this.selectedColor));
+        setBackground(this.selectedColor);
     }
 
     /**
@@ -97,11 +89,5 @@ public class ColorPicker extends CLabel {
             throw new IllegalArgumentException("null"); //$NON-NLS-1$
         }
         update(backgroundColor.getRGB());
-    }
-
-    @Override
-    public void dispose() {
-        super.dispose();
-        this.image.dispose();
     }
 }

--- a/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/style/editor/SeparatorPanel.java
+++ b/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/style/editor/SeparatorPanel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2020 Original authors and others.
+ * Copyright (c) 2012, 2025 Original authors and others.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,7 +13,6 @@
 package org.eclipse.nebula.widgets.nattable.style.editor;
 
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.layout.GridData;
@@ -21,6 +20,7 @@ import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Text;
 
 /**
  * Adds a separator line and label to the parent panel.
@@ -42,7 +42,7 @@ public class SeparatorPanel extends Composite {
         setLayoutData(layoutData);
 
         // Text label
-        StyledText gridLinesLabel = new StyledText(this, SWT.NONE);
+        Text gridLinesLabel = new Text(this, SWT.NONE);
         gridLinesLabel.setEditable(false);
         Display display = Display.getDefault();
         FontData data = display.getSystemFont().getFontData()[0];

--- a/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/ui/ExceptionDialog.java
+++ b/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/ui/ExceptionDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 Dirk Fauth and others.
+ * Copyright (c) 2016, 2025 Dirk Fauth and others.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,6 +19,7 @@ import java.io.StringWriter;
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.layout.GridDataFactory;
+import org.eclipse.nebula.widgets.nattable.util.PlatformHelper;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Point;
@@ -101,9 +102,9 @@ public class ExceptionDialog extends Dialog {
     @Override
     protected void createButtonsForButtonBar(Composite parent) {
         // create OK and Details buttons
-        createButton(parent, IDialogConstants.OK_ID, IDialogConstants.OK_LABEL, true);
+        createButton(parent, IDialogConstants.OK_ID, PlatformHelper.getIDialogConstantsLabel("OK_LABEL"), true); //$NON-NLS-1$
         if (this.exception != null) {
-            this.detailsButton = createButton(parent, IDialogConstants.DETAILS_ID, IDialogConstants.SHOW_DETAILS_LABEL, false);
+            this.detailsButton = createButton(parent, IDialogConstants.DETAILS_ID, PlatformHelper.getIDialogConstantsLabel("SHOW_DETAILS_LABEL"), false); //$NON-NLS-1$
         }
     }
 
@@ -123,11 +124,11 @@ public class ExceptionDialog extends Dialog {
         if (this.exceptionAreaCreated) {
             this.exceptionText.dispose();
             this.exceptionAreaCreated = false;
-            this.detailsButton.setText(IDialogConstants.SHOW_DETAILS_LABEL);
+            this.detailsButton.setText(PlatformHelper.getIDialogConstantsLabel("SHOW_DETAILS_LABEL")); //$NON-NLS-1$
             opened = false;
         } else {
             this.exceptionText = createExceptionText((Composite) getContents());
-            this.detailsButton.setText(IDialogConstants.HIDE_DETAILS_LABEL);
+            this.detailsButton.setText(PlatformHelper.getIDialogConstantsLabel("HIDE_DETAILS_LABEL")); //$NON-NLS-1$
             getContents().getShell().layout();
             opened = true;
         }

--- a/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/ui/mode/ModeSupport.java
+++ b/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/ui/mode/ModeSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2020 Original authors and others.
+ * Copyright (c) 2012, 2025 Original authors and others.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,6 +16,7 @@ package org.eclipse.nebula.widgets.nattable.ui.mode;
 import java.util.EnumMap;
 
 import org.eclipse.nebula.widgets.nattable.NatTable;
+import org.eclipse.nebula.widgets.nattable.util.PlatformHelper;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.FocusEvent;
 import org.eclipse.swt.events.FocusListener;
@@ -34,12 +35,6 @@ import org.eclipse.swt.events.MouseTrackListener;
  */
 public class ModeSupport implements KeyListener, MouseListener, MouseMoveListener, MouseTrackListener, FocusListener {
 
-    private static final boolean IS_MAC;
-
-    static {
-        IS_MAC = System.getProperty("os.name").toLowerCase().indexOf("mac") >= 0; //$NON-NLS-1$ //$NON-NLS-2$
-    }
-
     private EnumMap<Mode, IModeEventHandler> modeEventHandlerMap = new EnumMap<>(Mode.class);
 
     private IModeEventHandler currentModeEventHandler;
@@ -47,9 +42,10 @@ public class ModeSupport implements KeyListener, MouseListener, MouseMoveListene
     public ModeSupport(NatTable natTable) {
         natTable.addKeyListener(this);
         natTable.addMouseListener(this);
-        natTable.addMouseMoveListener(this);
-        natTable.addMouseTrackListener(this);
         natTable.addFocusListener(this);
+
+        PlatformHelper.callSetter(natTable, "addMouseMoveListener", MouseMoveListener.class, this); //$NON-NLS-1$
+        PlatformHelper.callSetter(natTable, "addMouseTrackListener", MouseTrackListener.class, this); //$NON-NLS-1$
     }
 
     /**
@@ -157,7 +153,7 @@ public class ModeSupport implements KeyListener, MouseListener, MouseMoveListene
      *            The {@link MouseEvent} to modify
      */
     private void modifyMouseEventForMac(MouseEvent event) {
-        if (IS_MAC && event.stateMask == SWT.MOD4 && event.button == 1) {
+        if (PlatformHelper.isMAC() && event.stateMask == SWT.MOD4 && event.button == 1) {
             event.stateMask = event.stateMask & ~SWT.MOD4;
             event.button = 3;
         }

--- a/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/ui/scaling/ScalingUiBindingConfiguration.java
+++ b/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/ui/scaling/ScalingUiBindingConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 Dirk Fauth and others.
+ * Copyright (c) 2020, 2025 Dirk Fauth and others.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,7 +19,9 @@ import org.eclipse.nebula.widgets.nattable.config.AbstractUiBindingConfiguration
 import org.eclipse.nebula.widgets.nattable.config.IConfigRegistry;
 import org.eclipse.nebula.widgets.nattable.ui.binding.UiBindingRegistry;
 import org.eclipse.nebula.widgets.nattable.ui.matcher.KeyEventMatcher;
+import org.eclipse.nebula.widgets.nattable.util.PlatformHelper;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.MouseWheelListener;
 
 /**
  * Default configuration to add bindings to change the scaling / zoom level of a
@@ -101,8 +103,8 @@ public class ScalingUiBindingConfiguration extends AbstractUiBindingConfiguratio
      * @since 2.6
      */
     public ScalingUiBindingConfiguration(NatTable natTable, boolean percentageScalingChange, Consumer<IConfigRegistry> updater) {
-        if (natTable != null) {
-            natTable.addMouseWheelListener(new ScalingMouseWheelListener(percentageScalingChange, updater));
+        if (natTable != null && !PlatformHelper.isRAP()) {
+            PlatformHelper.callSetter(natTable, "addMouseWheelListener", MouseWheelListener.class, new ScalingMouseWheelListener(percentageScalingChange, updater)); //$NON-NLS-1$
         }
         this.percentageScalingChange = percentageScalingChange;
         this.updater = updater;

--- a/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/util/PlatformHelper.java
+++ b/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/util/PlatformHelper.java
@@ -1,0 +1,173 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Dirk Fauth and others.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Dirk Fauth <dirk.fauth@googlemail.com> - initial API and implementation
+ ******************************************************************************/
+package org.eclipse.nebula.widgets.nattable.util;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.swt.SWT;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Helper class that is used to handle differences in platform implementations
+ * of SWT. For example to call methods that are available in SWT but not in the
+ * RAP/RWT implementation.
+ *
+ * @since 2.6
+ */
+public final class PlatformHelper {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PlatformHelper.class);
+
+    private static final boolean IS_MAC;
+
+    static {
+        IS_MAC = System.getProperty("os.name").toLowerCase().indexOf("mac") >= 0; //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    private PlatformHelper() {
+        // empty private constructor to prevent instantiation
+    }
+
+    /**
+     *
+     * @return <code>true</code> if the SWT platform is <i>rap</i>,
+     *         <code>false</code> if not.
+     */
+    public static boolean isRAP() {
+        return "rap".equals(SWT.getPlatform()); //$NON-NLS-1$
+    }
+
+    /**
+     * Checks the system property <i>os.name</i> if we are running on a Mac.
+     *
+     * @return <code>true</code> if we we are executed on a mac,
+     *         <code>false</code> if not.
+     */
+    public static boolean isMAC() {
+        return IS_MAC;
+    }
+
+    private static Map<String, Optional<Method>> METHOD_MAPPING = new ConcurrentHashMap<>();
+
+    /**
+     * Tries to invoke a getter method on the given object.
+     *
+     * @param obj
+     *            The object on which the getter method should be invoked.
+     * @param methodName
+     *            The name of the getter method to invoke.
+     * @return The return value of the getter method or <code>null</code> if the
+     *         method does not exist or fails.
+     */
+    public static Object callGetter(Object obj, String methodName) {
+        String key = obj.getClass().getName() + "#" + methodName; //$NON-NLS-1$
+        Optional<Method> method = METHOD_MAPPING.computeIfAbsent(key, (k) -> {
+            try {
+                Method m = obj.getClass().getMethod(methodName);
+                return Optional.of(m);
+            } catch (NoSuchMethodException | IllegalArgumentException e) {
+                return Optional.empty();
+            }
+
+        });
+        if (method.isPresent()) {
+            try {
+                return method.get().invoke(obj);
+            } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+                LOG.error("Failed to invoke method \"{}\" on \"{}\"", methodName, obj.getClass().getName(), e); //$NON-NLS-1$
+                return null;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Tries to invoke a setter method on the given object. Simply does nothing
+     * if the setter method does not exist or the invocation fails.
+     *
+     * @param obj
+     *            The object on which the setter method should be invoked.
+     * @param methodName
+     *            The name of the setter method to invoke.
+     * @param parameterType
+     *            The method parameter.
+     * @param parameterValue
+     *            The parameter value to set.
+     */
+    public static void callSetter(Object obj, String methodName, Class<?> parameterType, Object parameterValue) {
+        callSetter(obj, methodName, new Class<?>[] { parameterType }, new Object[] { parameterValue });
+    }
+
+    /**
+     * Tries to invoke a setter method on the given object. Simply does nothing
+     * if the setter method does not exist or the invocation fails.
+     *
+     * @param obj
+     *            The object on which the setter method should be invoked.
+     * @param methodName
+     *            The name of the setter method to invoke.
+     * @param parameterTypes
+     *            The list of method parameters.
+     * @param parameterValues
+     *            The list of parameter values to set.
+     */
+    public static void callSetter(Object obj, String methodName, Class<?>[] parameterTypes, Object[] parameterValues) {
+        String key = obj.getClass().getName() + "#" + methodName + "#" + Arrays.toString(parameterTypes); //$NON-NLS-1$ //$NON-NLS-2$
+        Optional<Method> method = METHOD_MAPPING.computeIfAbsent(key, (k) -> {
+            try {
+                Method m = obj.getClass().getMethod(methodName, parameterTypes);
+                return Optional.of(m);
+            } catch (NoSuchMethodException | IllegalArgumentException e) {
+                return Optional.empty();
+            }
+
+        });
+        if (method.isPresent()) {
+            try {
+                method.get().invoke(obj, parameterValues);
+            } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+                LOG.error("Failed to invoke method \"{}\" on \"{}\"", methodName, obj.getClass().getName(), e); //$NON-NLS-1$
+            }
+        }
+        // else simply do nothing, method does not exist
+    }
+
+    /**
+     * Get a label from {@link IDialogConstants}. Needed because in SWT you can
+     * access the constants directly, while in RWT you need to get an instance
+     * from which to access the constant.
+     *
+     * @param label
+     *            The name of the constant for which the label is requested.
+     * @return The label for the given label key.
+     */
+    public static String getIDialogConstantsLabel(String label) {
+        try {
+            if (IDialogConstants.class.isInterface()) {
+                return IDialogConstants.class.getField(label).get(null).toString();
+            }
+            Method get = IDialogConstants.class.getMethod("get"); //$NON-NLS-1$
+            IDialogConstants invoke = (IDialogConstants) get.invoke(null);
+            return invoke.getClass().getField(label).get(invoke).toString();
+        } catch (NoSuchMethodException | SecurityException | IllegalArgumentException | IllegalAccessException | NoSuchFieldException | InvocationTargetException e) {
+            return ""; //$NON-NLS-1$
+        }
+    }
+}

--- a/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/viewport/ScrollBarScroller.java
+++ b/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/viewport/ScrollBarScroller.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2021 Edwin Park and others.
+ * Copyright (c) 2013, 2025 Edwin Park and others.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.nebula.widgets.nattable.viewport;
 
+import org.eclipse.nebula.widgets.nattable.util.PlatformHelper;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.ScrollBar;
@@ -81,12 +82,16 @@ public class ScrollBarScroller implements IScroller<ScrollBar> {
 
     @Override
     public int getPageIncrement() {
-        return this.scrollBar.getPageIncrement();
+        Object result = PlatformHelper.callGetter(this.scrollBar, "getPageIncrement"); //$NON-NLS-1$
+        if (result != null) {
+            return (int) result;
+        }
+        return 0;
     }
 
     @Override
     public void setPageIncrement(int value) {
-        this.scrollBar.setPageIncrement(value);
+        PlatformHelper.callSetter(this.scrollBar, "setPageIncrement", int.class, value); //$NON-NLS-1$
     }
 
     @Override
@@ -101,12 +106,16 @@ public class ScrollBarScroller implements IScroller<ScrollBar> {
 
     @Override
     public int getIncrement() {
-        return this.scrollBar.getIncrement();
+        Object result = PlatformHelper.callGetter(this.scrollBar, "getIncrement"); //$NON-NLS-1$
+        if (result != null) {
+            return (int) result;
+        }
+        return 0;
     }
 
     @Override
     public void setIncrement(int value) {
-        this.scrollBar.setIncrement(value);
+        PlatformHelper.callSetter(this.scrollBar, "setIncrement", int.class, value); //$NON-NLS-1$
     }
 
     @Override

--- a/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/widget/NatCombo.java
+++ b/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/widget/NatCombo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2024 Original authors and others.
+ * Copyright (c) 2012, 2025 Original authors and others.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -520,11 +520,11 @@ public class NatCombo extends Composite {
         getShell().addListener(SWT.Move, moveListener);
 
         addDisposeListener(e -> {
-            if (NatCombo.this.dropdownShell != null) {
-                NatCombo.this.dropdownShell.dispose();
-            }
-            NatCombo.this.text.dispose();
             NatCombo.this.getShell().removeListener(SWT.Move, moveListener);
+
+            if (NatCombo.this.dropdownShell != null && !NatCombo.this.dropdownShell.isDisposed()) {
+                NatCombo.this.dropdownShell.close();
+            }
         });
     }
 
@@ -752,7 +752,7 @@ public class NatCombo extends Composite {
                         }
                         event.doit = false;
                     }
-                } else if (event.keyCode == SWT.SPACE) {
+                } else if (event.keyCode == ' ') {
                     if (NatCombo.this.multiselect && NatCombo.this.useCheckbox && NatCombo.this.dropdownTable.getSelectionCount() >= 1) {
                         TableItem[] selection = NatCombo.this.dropdownTable.getSelection();
                         boolean isSelected = selection[0].getChecked();
@@ -777,6 +777,12 @@ public class NatCombo extends Composite {
                 boolean isShiftPressed = (e.stateMask & SWT.MODIFIER_MASK) == SWT.MOD2;
                 TableItem chosenItem = (TableItem) e.item;
 
+                // if no item is set in the SelectionEvent, we simply do nothing
+                // this seems to only happen in Eclipse 3 compatibility mode on
+                // pressing CTRL + A when the dropdown table has focus
+                if (chosenItem == null) {
+                    return;
+                }
                 // Given the ability to filter we need to find the item's
                 // table index which may not match the index in the itemList
                 int itemTableIndex = NatCombo.this.dropdownTable.indexOf(chosenItem);
@@ -1413,6 +1419,9 @@ public class NatCombo extends Composite {
     public void notifyListeners(int eventType, Event event) {
         if (this.dropdownTable != null && !this.dropdownTable.isDisposed()) {
             this.dropdownTable.notifyListeners(eventType, event);
+        }
+        if (!isDisposed()) {
+            super.notifyListeners(eventType, event);
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
 	</modules>
 
 	<properties>
-		<tycho-version>4.0.10</tycho-version>
+		<tycho-version>4.0.12</tycho-version>
         <cbi-version>1.5.2</cbi-version>
         <nattable-version>${project.version}</nattable-version>
 		

--- a/target-platform/target-platform.target
+++ b/target-platform/target-platform.target
@@ -16,10 +16,11 @@
       <unit id="org.eclipse.collections.feature.feature.group" version="0.0.0"/>
       <repository location="https://download.eclipse.org/collections/11.1.0/repository"/>
     </location>
+    <!-- Stick with Nebula 3.1.1 for the moment, because CDateTime introduces a dependency update to SWT >= 3.126.0, which is at least Eclipse 2024-06 (4.32)  -->
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="org.eclipse.nebula.widgets.cdatetime" version="0.0.0"/>
       <unit id="org.eclipse.nebula.widgets.richtext" version="0.0.0"/>
-      <repository location="https://download.eclipse.org/nebula/updates/milestone/latest"/>
+      <repository location="https://download.eclipse.org/nebula/releases/latest"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="ca.odell.glazedlists" version="0.0.0"/>


### PR DESCRIPTION
Introduced a new helper class `org.eclipse.nebula.widgets.nattable.util.PlatformHelper` that contains methods to handle situations that differ between platforms.

This class contains the following:
- Special handling for getting `IDialogConstants` values, because in SWT you access those constants directly from the `IDialogConstants` interface, in RAP/RWT you first need to get an instance before you can access the contants.  
`IDialogConstants` are used in the NatTable `ExceptionDialog` which is mainly used in the `NatExporter`.
- Methods to get information about the platform, `isRAP()` and `isMAC()` to be able to handle situations where processing needs to be skipped completely (e.g. when trying to trigger printing) or to handle situations differently when in RAP or running on a MAC.
- Methods to call methods in SWT and JFace implementations via reflection. This is needed because RAP/RWT does not implement several methods that are defined in SWT and therefore a direct call to this methods works in SWT but fails with an error in RAP.

Following methods are missing in RWT:
- `FontMetrics#getDescent()`
- `FontMetrics#getAscent()`
- `FontMetrics#getLeading()`

These methods are used in `AbstractTextPainter`, `GraphicsUtils` and `VerticalTextPainter`. Without these there are no textdecorations (underline, strikethrough) available in NatTable with RAP. And the location of the text in vertical text representation might be not 100% accurate.


- `FileDialog#getFilterIndex()`
- `FileDialog#setFilterPath(String)`
- `FileDialog#setOverwrite(boolean)`
- `FileDialog#setFileName(String)`
- `FileDialog#setFilterNames(String[])`

Used in `FileOutputStreamProvider` that opens a `FileDialog` to select the target on exporting a NatTable and in the `FileDialogCellEditor`.  
Note that the `FileDialog` in RAP can only be used to select a file for upload (`SWT.OPEN`) and not for saving (`SWT.SAVE`). 
Therefore the `FileOutputStreamProvider` was modified to create the export with the default filename in a temp directory, which can then be downloaded via RAP API as described in [Service Handler and Downloads](https://eclipse.dev/rap/developers-guide/resources.html)


- `ScrollBar#getIncrement()`
- `ScrollBar#getPageIncrement()`
- `ScrollBar#setIncrement(int)`
- `ScrollBar#setPageIncrement(int)`

Used in `ScrollBarScroller` and is called by `ScrollBarHandlerTemplate` (only `setIncrement(int)` and `setPageIncrement(int)`). As RAP/RWT does not support `ScrollBar` on a `Canvas`, this should not have direct effect in RAP, despite that it does not break on opening a NatTable with scrolling in RAP.
Note that to support scrolling in NatTable, there need to be a workaround implementation in a RAP specific NatTable fragment.


- `Control#addPaintListener(PaintListener)`
- `Control#removePaintListener(PaintListener)`
- `ControlDecoration#showHoverText(String)`

These methods are used in the `ControlDecorationProvider`. The `PaintListener` methods are used to position the error decoration correctly with the default positioning, because the cell bounds are only available after `activateCell()`.
This means, the `SWT.DEFAULT` decoration position does not work in RAP.
The `PaintListener` methods are also used to correct the position of the filter combobox in case filtering removes the scrollbar and the table would therefore be moved. This does also not work on RAP, but is more like a small visual glitch in a special case.

- `NatTable/Canvas#addMouseMoveListener(MouseMoveListener)`
- `NatTable/Canvas#addMouseTrackListener(MouseTrackListener)`
- `NatTable/Canvas#addMouseWheelListener(MouseWheelListener)`

Mouse move and mouse track events are not supported in RAP because of performance reasons. The support for mouse move in NatTable, for example to support column and row resizing or reordering, needs to be implemented in a RAP specific NatTable fragment using Javascript.
The hover styling on the other hand will not be supported in NatTable with RAP. To support this the mouse move events needs to be transported from the browser client to the server side, which will be a performance and networking issue.
The mouse wheel events are not supported for Canvas, although there should be no performance issue. But probably it is not supported because in RAP `Canvas` does not support scrollbars, so the mouse wheel support doesn't seem to be necessary.
Therefore the `ScalingMouseWheelListener` can not be used in NatTable with RAP and the instantiation and registration is suppressed in case of RAP.
Note that the `ScalingUiBindingConfiguration` doesn't seem to affect NatTable in RAP anyway, because the key bindings and the mouse wheel binding is used to zoom in and out via the browser and the interactions doesn't seem to be tracked in the `UiBindingRegistry` afterwards.

- The packages `org.eclipse.swt.printing` and `org.eclipse.swt.program` are not available in RAP and therefore now defined as optional package dependencies in the MANIFEST.

RAP does not support printing, so all print related classes are not available. All print related actions in NatTable are encapsulated in `org.eclipse.nebula.widgets.nattable.print.LayerPrinter`. 
To avoid the instantiation of a `LayerPrinter` with RAP, the `PrintCommandHandler` now only triggers the instantiation and printing if the platform is not RAP.
In places where the printing is customized in downstream projects, such a guard needs to be added there in case the rendering with RAP is planned.
As `org.eclipse.swt.program.Program` is not available in RAP, it is not supported that a generated Excel export is directly opened after the export finishes.

- `org.eclipse.jface.window.ToolTip`
- `org.eclipse.jface.window.DefaultToolTip`

Therefore the NatTable tooltip support via `NatTableContentTooltip` and subclasses like `FormulaTooltipErrorReporter` are not supported in NatTable in RAP.
As these classes can not even be instantiated in RAP, downstream projects need to add a guard to avoid that in their own code.

- `org.eclipse.jface.viewers.StyledCellLabelProvider`
- `org.eclipse.jface.viewers.StyledString`
- `org.eclipse.jface.viewers.StyledString.Styler`

These classes are used in the `PersistenceDialog` to render the default view configuration italic. 
To support the `PersistenceDialog` also in RAP, a new `SimpleViewConfigurationNameLabelProvider` was added that does not support the italic rendering.
This `SimpleViewConfigurationNameLabelProvider` will be used in case the platform is RAP.

- `org.eclipse.swt.graphics.Pattern`
- `org.eclipse.swt.graphics.Region`

Without the support of these two classes, the NatTable painter `BackgroundImagePainter` and `PercentageBarDecorator` are not supported in NatTable in RAP.
They need to be removed or programmatically conditionally replaced by something else if the NatTable configuration should be used in SWT and RAP.

- `SWT.MeasureItem`

As this event is not available in RAP, it is not possible to configure a fixed sub cell height in a `TableCellEditor`.


- `Cursor` constructors

RAP does not support custom `Cursor`. The necessary constructors in the `Cursor` class are missing. 
As the custom `Cursor` implementations in NatTable are registered in handlers of the mouse move events, which by default are not supported in RAP (see above), this should not be an issue for NatTable in RAP.

- `GC` instantiation on an `Image`

RAP only allows painting on the Canvas widget.
In NatTable there are several places where such `GC` instances are created to render the NatTable in memory for example and directly disposed to avoid resource leaks. 
In places that are not usable in RAP anyway (e.g. drag modes and `AutoResizeHelper` in memory rendering on print) the codes stays untouched. The `NatExporter` now has a guard to avoid the in memory rendering for auto resize on export too, as this leads to an exception.
Also the code in `GraphicsUtils` stays untouched. The methods in charge are only used by the `VerticalTextImagePainter`. If vertical text rendering is required, switch to the `VerticalTextPainter` which directly renders the transformed text on NatTable and does not create a temporary image that gets rotated.
In places that are reachable in RAP (e.g. `ImageExporter`, ) the usage in RAP is not supported and guarded to avoid runtime issues. 

As of now the Nebula Extension and the E4 Extension are not usable with RAP. This is mostly due to dependency issues, e.g. there are versioned package imports that can not be satisfied by RAP/RWT or there are `Require-Bundle` dependencies on `org.eclipse.swt` which can not be resolved.

There is an issue related to redrawing NatTable in case of visual changes. NatTable is collecting `IVisualChangeEvents` and triggers a redraw by default only every 20ms. 
This is to avoid that too many redraw operations are handled, which for example could happen on sorting or filtering when using GlazedLists.
The reason why this is not working in RAP is, that UI updates from a background thread are not automatically processed. This is described in more detail in [RAP Developer's Guide - Server Push](https://eclipse.dev/rap/developers-guide/server-push.html).
To fix this a `ServerPushSession` needs to be created and started for a NatTable instance. As this is RAP specific API, this issue needs to be addressed in a RAP specific NatTable fragment.

NatTable adds a `ResizeListener` to close an open editor if the parent `Composite` is resized. This is to keep the editor position and size in synch with the NatTable presentation. Unfortunately RAP is triggering strange resize events for unknown reasons in several places. 
This leads to suddenly closed editors. To avoid this, the `ResizeListener` are not registered if the platform is RAP.

In RAP there is a difference in the event processing compared to SWT. The order in which for example key events are processed differs, for example if a `TextCellEditor` is opened in a dialog, pressing ENTER in SWT will first trigger a push on the OK button in the dialog, then key event in the `Text` control.
But in RWT the key event is first processed in the `Text` control and then in the dialog. Therefore the commit on enter is disabled when the platform is RAP and the editor is opened in a dialog.

The `NatCombo` needed a modification to be usable as cell editor in NatTable. The `#notifyListener()` method needs to call the super implementation, which is necessary in RAP in order to manage the lifecycle correctly. This was not necessary in SWT. 
With some additional checks this change does not seem to affect the `NatCombo` in SWT and now works correctly in RAP.

A collection of limitations in RAP/RWT can be found in the [RAP Developers Guide](https://eclipse.dev/rap/developers-guide/rwt.html)

